### PR TITLE
feat: visão admin de clientes com contas, histórico e pagamento

### DIFF
--- a/src/components/account-card/index.tsx
+++ b/src/components/account-card/index.tsx
@@ -1,0 +1,46 @@
+import dayjs from "dayjs";
+import { formatToBRL } from "src/helpers/format-currency";
+import {
+  getPaymentStateColor,
+  getPaymentStateLabel,
+  isOpenAccount,
+} from "src/helpers/payment-state";
+import { UserAccountProps } from "src/services/user/types";
+import * as S from "./styles";
+
+type AccountCardProps = {
+  account: UserAccountProps;
+  onPress?: () => void;
+};
+
+export function AccountCard({ account, onPress }: AccountCardProps) {
+  const accountIsOpen = isOpenAccount(account.payment_state);
+  const paymentStateColor = getPaymentStateColor(account.payment_state);
+
+  return (
+    <S.CardSurface
+      isOpenAccount={accountIsOpen}
+      onPress={onPress}
+      disabled={!onPress}
+    >
+      <S.CardHeaderRow>
+        <S.AccountIdentifier>Conta #{account.id}</S.AccountIdentifier>
+        <S.PaymentStateText color={paymentStateColor}>
+          {getPaymentStateLabel(account.payment_state)}
+        </S.PaymentStateText>
+      </S.CardHeaderRow>
+      <S.CardRow>
+        <S.CardLabel>Atualizada em</S.CardLabel>
+        <S.CardValue>
+          {dayjs(account.updated_at).format("DD/MM/YYYY HH:mm")}
+        </S.CardValue>
+      </S.CardRow>
+      {accountIsOpen && (
+        <S.CardRow>
+          <S.CardLabel>Saldo em aberto</S.CardLabel>
+          <S.BalanceValue>{formatToBRL(account.total)}</S.BalanceValue>
+        </S.CardRow>
+      )}
+    </S.CardSurface>
+  );
+}

--- a/src/components/account-card/styles.ts
+++ b/src/components/account-card/styles.ts
@@ -1,0 +1,57 @@
+import theme from "src/styles/theme";
+import styled from "styled-components/native";
+
+export const CardSurface = styled.TouchableOpacity.attrs({
+  activeOpacity: 0.85,
+})<{ isOpenAccount: boolean }>`
+  background-color: ${theme.colors.WHITE};
+  border-radius: 12px;
+  padding: ${theme.size.m4};
+  gap: ${theme.size.m2};
+  border-width: 2px;
+  border-color: ${({ isOpenAccount }) =>
+    isOpenAccount ? theme.colors.ORANGE_200 : theme.colors.GRAY_200};
+  opacity: ${({ isOpenAccount }) => (isOpenAccount ? 1 : 0.85)};
+`;
+
+export const CardHeaderRow = styled.View`
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+export const AccountIdentifier = styled.Text`
+  color: ${theme.colors.GRAY_600};
+  font-size: ${theme.font.size.m5};
+  font-weight: ${theme.font.weight.bold};
+`;
+
+export const PaymentStateText = styled.Text<{ color: string }>`
+  color: ${({ color }) => color};
+  font-size: ${theme.font.size.m4};
+  font-weight: ${theme.font.weight.bold};
+`;
+
+export const CardRow = styled.View`
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+export const CardLabel = styled.Text`
+  color: ${theme.colors.GRAY_300};
+  font-size: ${theme.font.size.m4};
+  font-weight: ${theme.font.weight.semibold};
+`;
+
+export const CardValue = styled.Text`
+  color: ${theme.colors.GRAY_600};
+  font-size: ${theme.font.size.m4};
+  font-weight: ${theme.font.weight.bold};
+`;
+
+export const BalanceValue = styled.Text`
+  color: ${theme.colors.ORANGE_300};
+  font-size: ${theme.font.size.m6};
+  font-weight: ${theme.font.weight.extrabold};
+`;

--- a/src/components/account-transaction-history/index.tsx
+++ b/src/components/account-transaction-history/index.tsx
@@ -1,0 +1,65 @@
+import dayjs from "dayjs";
+import { formatToBRL } from "src/helpers/format-currency";
+import theme from "src/styles/theme";
+import { UserAccountTransactionHistoryItem } from "src/services/transactions/types";
+import * as S from "./styles";
+
+type AccountTransactionHistoryProps = {
+  transactions: UserAccountTransactionHistoryItem[];
+};
+
+function getTransactionTypeLabel(transactionType: string) {
+  if (transactionType === "PAYMENT") {
+    return "Pagamento";
+  }
+  if (transactionType === "INTEREST") {
+    return "Débito / Juros";
+  }
+  return "Ajuste";
+}
+
+function getTransactionAmountColor(transactionType: string) {
+  if (transactionType === "PAYMENT") {
+    return theme.colors.GREEN;
+  }
+  return theme.colors.ORANGE_100;
+}
+
+export function AccountTransactionHistory({
+  transactions,
+}: AccountTransactionHistoryProps) {
+  if (transactions.length === 0) {
+    return (
+      <S.EmptyHistoryText>Nenhuma movimentação encontrada</S.EmptyHistoryText>
+    );
+  }
+
+  return (
+    <S.TimelineContainer>
+      {transactions.map((transaction) => (
+        <S.TransactionItem key={transaction.id}>
+          <S.TransactionHeaderRow>
+            <S.TransactionTypeText>
+              {getTransactionTypeLabel(transaction.type)}
+            </S.TransactionTypeText>
+            <S.TransactionAmount color={getTransactionAmountColor(transaction.type)}>
+              {formatToBRL(transaction.amount)}
+            </S.TransactionAmount>
+          </S.TransactionHeaderRow>
+          <S.TransactionMetaText>
+            {dayjs(transaction.created_at).format("DD/MM/YYYY HH:mm")}
+          </S.TransactionMetaText>
+          <S.TransactionMetaText>Conta #{transaction.order_id}</S.TransactionMetaText>
+          {transaction.payment_method && (
+            <S.TransactionMetaText>
+              Método: {transaction.payment_method}
+            </S.TransactionMetaText>
+          )}
+          {transaction.notes && (
+            <S.TransactionMetaText>{transaction.notes}</S.TransactionMetaText>
+          )}
+        </S.TransactionItem>
+      ))}
+    </S.TimelineContainer>
+  );
+}

--- a/src/components/account-transaction-history/styles.ts
+++ b/src/components/account-transaction-history/styles.ts
@@ -1,0 +1,45 @@
+import theme from "src/styles/theme";
+import styled from "styled-components/native";
+
+export const TimelineContainer = styled.View`
+  gap: ${theme.size.m3};
+`;
+
+export const TransactionItem = styled.View`
+  background-color: ${theme.colors.GRAY_100};
+  border-radius: 10px;
+  padding: ${theme.size.m4};
+  gap: ${theme.size.m2};
+`;
+
+export const TransactionHeaderRow = styled.View`
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+export const TransactionTypeText = styled.Text`
+  color: ${theme.colors.GRAY_600};
+  font-size: ${theme.font.size.m4};
+  font-weight: ${theme.font.weight.bold};
+`;
+
+export const TransactionAmount = styled.Text<{ color: string }>`
+  color: ${({ color }) => color};
+  font-size: ${theme.font.size.m5};
+  font-weight: ${theme.font.weight.extrabold};
+`;
+
+export const TransactionMetaText = styled.Text`
+  color: ${theme.colors.GRAY_300};
+  font-size: ${theme.font.size.m3};
+  font-weight: ${theme.font.weight.semibold};
+`;
+
+export const EmptyHistoryText = styled.Text`
+  color: ${theme.colors.GRAY_300};
+  font-size: ${theme.font.size.m4};
+  font-weight: ${theme.font.weight.semibold};
+  text-align: center;
+  padding: ${theme.size.m4};
+`;

--- a/src/components/tab-icon-container/index.tsx
+++ b/src/components/tab-icon-container/index.tsx
@@ -1,4 +1,3 @@
-import theme from "src/styles/theme";
 import * as S from "./styles";
 
 type TabIconContainerProps = {
@@ -6,12 +5,9 @@ type TabIconContainerProps = {
   children: React.ReactNode;
 };
 
-export const TabIconContainer = ({
+export function TabIconContainer({
   children,
   focused,
-}: TabIconContainerProps) => {
-  const getColor = (focused: boolean) => {
-    return focused ? theme.colors.ORANGE_200 : theme.colors.GRAY_100;
-  };
-  return <S.Container color={getColor(focused)}>{children}</S.Container>;
-};
+}: TabIconContainerProps) {
+  return <S.Container focused={focused}>{children}</S.Container>;
+}

--- a/src/components/tab-icon-container/styles.ts
+++ b/src/components/tab-icon-container/styles.ts
@@ -1,14 +1,16 @@
+import theme from "src/styles/theme";
 import styled from "styled-components/native";
 
-type CustomContainerProps = {
-  color: string;
+type TabIconContainerProps = {
+  focused: boolean;
 };
 
-export const Container = styled.View<CustomContainerProps>`
-  background-color: ${({ color }) => color};
+export const Container = styled.View<TabIconContainerProps>`
   justify-content: center;
   align-items: center;
-  height: 50px;
-  width: 50px;
-  border-radius: 99px;
+  width: 36px;
+  height: 32px;
+  border-radius: 10px;
+  background-color: ${({ focused }) =>
+    focused ? theme.colors.ORANGE_200 : "transparent"};
 `;

--- a/src/components/user-card/index.tsx
+++ b/src/components/user-card/index.tsx
@@ -1,0 +1,41 @@
+import { AccountSummary } from "src/services/user/types";
+import { formatToBRL } from "src/helpers/format-currency";
+import * as S from "./styles";
+
+type UserCardProps = {
+  username: string;
+  telephone: string;
+  accountSummary: AccountSummary;
+  onPress?: () => void;
+};
+
+export function UserCard({
+  username,
+  telephone,
+  accountSummary,
+  onPress,
+}: UserCardProps) {
+  return (
+    <S.CardSurface onPress={onPress} disabled={!onPress}>
+      <S.CustomerName>{username}</S.CustomerName>
+      <S.RowContainer>
+        <S.RowLabel>Telefone</S.RowLabel>
+        <S.RowValue>{telephone}</S.RowValue>
+      </S.RowContainer>
+      <S.RowContainer>
+        <S.RowLabel>Saldo total em aberto</S.RowLabel>
+        <S.OpenBalanceValue>
+          {formatToBRL(accountSummary.openBalance)}
+        </S.OpenBalanceValue>
+      </S.RowContainer>
+      <S.RowContainer>
+        <S.RowLabel>Contas em aberto</S.RowLabel>
+        <S.RowValue>{accountSummary.openAccountsCount}</S.RowValue>
+      </S.RowContainer>
+      <S.RowContainer>
+        <S.RowLabel>Contas vencidas</S.RowLabel>
+        <S.RowValue>{accountSummary.overdueAccountsCount}</S.RowValue>
+      </S.RowContainer>
+    </S.CardSurface>
+  );
+}

--- a/src/components/user-card/styles.ts
+++ b/src/components/user-card/styles.ts
@@ -1,0 +1,52 @@
+import theme from "src/styles/theme";
+import styled from "styled-components/native";
+
+export const CardSurface = styled.TouchableOpacity.attrs({
+  activeOpacity: 0.85,
+})`
+  background-color: ${theme.colors.WHITE};
+  border-radius: 12px;
+  padding: ${theme.size.m5};
+  gap: ${theme.size.m3};
+  width: 100%;
+  border-top-width: 4px;
+  border-top-color: ${theme.colors.ORANGE_300};
+  elevation: 4;
+  shadow-color: #000;
+  shadow-opacity: 0.08;
+  shadow-radius: 6px;
+  shadow-offset: 0px 2px;
+`;
+
+export const CustomerName = styled.Text`
+  color: ${theme.colors.GRAY_600};
+  font-size: ${theme.font.size.m7};
+  font-weight: ${theme.font.weight.extrabold};
+`;
+
+export const RowContainer = styled.View`
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  gap: ${theme.size.m3};
+`;
+
+export const RowLabel = styled.Text`
+  color: ${theme.colors.GRAY_300};
+  font-size: ${theme.font.size.m4};
+  font-weight: ${theme.font.weight.semibold};
+  flex: 1;
+`;
+
+export const RowValue = styled.Text`
+  color: ${theme.colors.GRAY_600};
+  font-size: ${theme.font.size.m4};
+  font-weight: ${theme.font.weight.bold};
+  text-align: right;
+`;
+
+export const OpenBalanceValue = styled.Text`
+  color: ${theme.colors.ORANGE_300};
+  font-size: ${theme.font.size.m8};
+  font-weight: ${theme.font.weight.extrabold};
+`;

--- a/src/components/users-list/index.tsx
+++ b/src/components/users-list/index.tsx
@@ -1,0 +1,64 @@
+import {
+  ActivityIndicator,
+  FlatList,
+  ListRenderItem,
+  RefreshControl,
+} from "react-native";
+import theme from "src/styles/theme";
+import { AdminUserListItem } from "src/services/user/types";
+import * as S from "./styles";
+
+type UsersListProps = {
+  users: AdminUserListItem[];
+  emptyListMessage: string;
+  onRefresh: () => void;
+  onEndList?: () => void;
+  refreshing: boolean;
+  itemSeparatorComponent: React.ComponentType;
+  renderItem: ListRenderItem<AdminUserListItem>;
+};
+
+export function UsersList({
+  users,
+  emptyListMessage,
+  onRefresh,
+  onEndList,
+  refreshing,
+  itemSeparatorComponent,
+  renderItem,
+}: UsersListProps) {
+  const footerComponent = () => {
+    if (!refreshing) {
+      return null;
+    }
+
+    return <ActivityIndicator size="large" />;
+  };
+
+  return (
+    <S.CardArea>
+      <FlatList
+        data={users}
+        renderItem={renderItem}
+        keyExtractor={(item) => item.id.toString()}
+        extraData={refreshing}
+        showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl
+            onRefresh={onRefresh}
+            refreshing={refreshing}
+            tintColor={theme.colors.WHITE}
+          />
+        }
+        ListEmptyComponent={
+          <S.EmptyListContainer>
+            <S.EmptyListText>{emptyListMessage}</S.EmptyListText>
+          </S.EmptyListContainer>
+        }
+        onEndReached={onEndList}
+        ListFooterComponent={footerComponent}
+        ItemSeparatorComponent={itemSeparatorComponent}
+      />
+    </S.CardArea>
+  );
+}

--- a/src/components/users-list/styles.ts
+++ b/src/components/users-list/styles.ts
@@ -1,0 +1,19 @@
+import theme from "src/styles/theme";
+import styled from "styled-components/native";
+
+export const CardArea = styled.View`
+  flex: 1;
+`;
+
+export const EmptyListContainer = styled.View`
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  height: 80px;
+`;
+
+export const EmptyListText = styled.Text`
+  color: ${theme.colors.WHITE};
+  font-size: 18px;
+  font-weight: bold;
+`;

--- a/src/helpers/payment-state.ts
+++ b/src/helpers/payment-state.ts
@@ -1,0 +1,30 @@
+import theme from "src/styles/theme";
+import { OrderPaymentStatus } from "src/types/orders";
+
+const paymentStateLabels: Record<OrderPaymentStatus, string> = {
+  PENDENTE: "Pendente",
+  PAGO: "Pago",
+  VENCIDO: "Vencido",
+  PARCIALMENTE_PAGO: "Parcialmente pago",
+};
+
+export function getPaymentStateLabel(paymentState: OrderPaymentStatus | string) {
+  return paymentStateLabels[paymentState as OrderPaymentStatus] ?? paymentState;
+}
+
+export function getPaymentStateColor(paymentState: OrderPaymentStatus | string) {
+  if (paymentState === "PAGO") {
+    return theme.colors.GREEN;
+  }
+  if (paymentState === "VENCIDO") {
+    return theme.colors.RED_100;
+  }
+  if (paymentState === "PARCIALMENTE_PAGO") {
+    return theme.colors.ORANGE_100;
+  }
+  return theme.colors.ORANGE_100;
+}
+
+export function isOpenAccount(paymentState: OrderPaymentStatus | string) {
+  return paymentState !== "PAGO";
+}

--- a/src/routes/admin-bottom-tab.routes.tsx
+++ b/src/routes/admin-bottom-tab.routes.tsx
@@ -7,10 +7,12 @@ import { OrdersListScreen } from "@screens/user/orders-list";
 import { UserProfile } from "@screens/user/profile";
 import theme from "src/styles/theme";
 import { Home } from "../screens/admin/home";
+import { AdminUsersListScreen } from "../screens/admin/users-list";
 
 type UserNavbarRoutesProps = {
   UserOrders: undefined;
   AdminHome: undefined;
+  AdminUsers: undefined;
   UserProfile: undefined;
 };
 
@@ -31,24 +33,30 @@ export function AdminBottomTabRoutes() {
     />
   );
 
-  const tabBarIconWidth = 28;
+  const tabBarIconWidth = 24;
 
   return (
     <Navigator
       screenOptions={{
         headerShown: false,
-        tabBarShowLabel: false,
-        tabBarActiveTintColor: theme.colors.GRAY_100,
-        tabBarInactiveTintColor: theme.colors.ORANGE_200,
+        tabBarShowLabel: true,
+        tabBarActiveTintColor: theme.colors.ORANGE_200,
+        tabBarInactiveTintColor: theme.colors.GRAY_300,
+        tabBarLabelStyle: {
+          fontSize: 11,
+          fontWeight: "700",
+          marginTop: 4,
+          marginBottom: 2,
+        },
         headerLeft: renderCustomBackButton,
         title: "",
         tabBarStyle: {
           backgroundColor: theme.colors.GRAY_100,
           borderTopWidth: 0,
           borderColor: "transparent",
-          paddingBottom: 20,
-          paddingTop: 10,
-          height: 80,
+          paddingBottom: 16,
+          paddingTop: 8,
+          height: 88,
         },
         animation: "shift",
       }}
@@ -57,9 +65,30 @@ export function AdminBottomTabRoutes() {
         name="AdminHome"
         component={Home}
         options={{
-          tabBarIcon: ({ color, focused }) => (
+          tabBarLabel: "Início",
+          tabBarIcon: ({ focused }) => (
             <TabIconContainer focused={focused}>
-              <Entypo name="home" size={tabBarIconWidth} color={color} />
+              <Entypo
+                name="home"
+                size={tabBarIconWidth}
+                color={focused ? theme.colors.WHITE : theme.colors.GRAY_300}
+              />
+            </TabIconContainer>
+          ),
+        }}
+      />
+      <Screen
+        name="AdminUsers"
+        component={AdminUsersListScreen}
+        options={{
+          tabBarLabel: "Clientes",
+          tabBarIcon: ({ focused }) => (
+            <TabIconContainer focused={focused}>
+              <Entypo
+                name="users"
+                size={tabBarIconWidth}
+                color={focused ? theme.colors.WHITE : theme.colors.GRAY_300}
+              />
             </TabIconContainer>
           ),
         }}
@@ -68,9 +97,14 @@ export function AdminBottomTabRoutes() {
         name="UserOrders"
         component={OrdersListScreen}
         options={{
-          tabBarIcon: ({ color, focused }) => (
+          tabBarLabel: "Pedidos",
+          tabBarIcon: ({ focused }) => (
             <TabIconContainer focused={focused}>
-              <Entypo name="list" size={tabBarIconWidth} color={color} />
+              <Entypo
+                name="list"
+                size={tabBarIconWidth}
+                color={focused ? theme.colors.WHITE : theme.colors.GRAY_300}
+              />
             </TabIconContainer>
           ),
         }}
@@ -79,10 +113,15 @@ export function AdminBottomTabRoutes() {
         name="UserProfile"
         component={UserProfile}
         options={{
+          tabBarLabel: "Perfil",
           tabBarStyle: { display: "none" },
-          tabBarIcon: ({ color, focused }) => (
+          tabBarIcon: ({ focused }) => (
             <TabIconContainer focused={focused}>
-              <Entypo name="user" size={tabBarIconWidth} color={color} />
+              <Entypo
+                name="user"
+                size={tabBarIconWidth}
+                color={focused ? theme.colors.WHITE : theme.colors.GRAY_300}
+              />
             </TabIconContainer>
           ),
         }}

--- a/src/routes/admin.routes.tsx
+++ b/src/routes/admin.routes.tsx
@@ -9,6 +9,7 @@ import { Platform } from "react-native";
 import theme from "src/styles/theme";
 import { ProductName } from "src/types/stock";
 import { AdminOrderDetailScreen } from "../screens/admin/order-detail";
+import { AdminUserDetailScreen } from "../screens/admin/user-detail";
 import { UserCreateOrder } from "../screens/user/create-order";
 import { OrderAddress } from "../screens/user/order-address";
 import { UserProfile } from "../screens/user/profile";
@@ -38,6 +39,7 @@ export type AdminRoutes = {
   };
   userProfile: undefined;
   orderDetail: { orderId: number };
+  userDetail: { userId: number };
 };
 
 export type AdminNavigatorRoutesProps = NativeStackNavigationProp<AdminRoutes>;
@@ -80,6 +82,7 @@ export function AdminRoutes() {
         <Screen name="orderAddress" component={OrderAddress} />
         <Screen name="userProfile" component={UserProfile} />
         <Screen name="orderDetail" component={AdminOrderDetailScreen} />
+        <Screen name="userDetail" component={AdminUserDetailScreen} />
       </Navigator>
     </LinearGradientBackground>
   );

--- a/src/routes/user-bottom-tab.routes.tsx
+++ b/src/routes/user-bottom-tab.routes.tsx
@@ -31,24 +31,30 @@ export function UserBottomTabRoutes() {
     />
   );
 
-  const tabBarIconWidth = 28;
+  const tabBarIconWidth = 24;
 
   return (
     <Navigator
       screenOptions={{
         headerShown: false,
-        tabBarShowLabel: false,
-        tabBarActiveTintColor: theme.colors.GRAY_100,
-        tabBarInactiveTintColor: theme.colors.ORANGE_200,
+        tabBarShowLabel: true,
+        tabBarActiveTintColor: theme.colors.ORANGE_200,
+        tabBarInactiveTintColor: theme.colors.GRAY_300,
+        tabBarLabelStyle: {
+          fontSize: 11,
+          fontWeight: "700",
+          marginTop: 4,
+          marginBottom: 2,
+        },
         headerLeft: renderCustomBackButton,
         title: "",
         tabBarStyle: {
           backgroundColor: theme.colors.GRAY_100,
           borderTopWidth: 0,
           borderColor: "transparent",
-          paddingBottom: 20,
-          paddingTop: 10,
-          height: 80,
+          paddingBottom: 16,
+          paddingTop: 8,
+          height: 88,
         },
         animation: "shift",
       }}
@@ -57,9 +63,14 @@ export function UserBottomTabRoutes() {
         name="UserHome"
         component={Home}
         options={{
-          tabBarIcon: ({ color, focused }) => (
+          tabBarLabel: "Início",
+          tabBarIcon: ({ focused }) => (
             <TabIconContainer focused={focused}>
-              <Entypo name="home" size={tabBarIconWidth} color={color} />
+              <Entypo
+                name="home"
+                size={tabBarIconWidth}
+                color={focused ? theme.colors.WHITE : theme.colors.GRAY_300}
+              />
             </TabIconContainer>
           ),
         }}
@@ -68,9 +79,14 @@ export function UserBottomTabRoutes() {
         name="UserOrders"
         component={OrdersListScreen}
         options={{
-          tabBarIcon: ({ color, focused }) => (
+          tabBarLabel: "Pedidos",
+          tabBarIcon: ({ focused }) => (
             <TabIconContainer focused={focused}>
-              <Entypo name="list" size={tabBarIconWidth} color={color} />
+              <Entypo
+                name="list"
+                size={tabBarIconWidth}
+                color={focused ? theme.colors.WHITE : theme.colors.GRAY_300}
+              />
             </TabIconContainer>
           ),
         }}
@@ -79,10 +95,15 @@ export function UserBottomTabRoutes() {
         name="UserProfile"
         component={UserProfile}
         options={{
+          tabBarLabel: "Perfil",
           tabBarStyle: { display: "none" },
-          tabBarIcon: ({ color, focused }) => (
+          tabBarIcon: ({ focused }) => (
             <TabIconContainer focused={focused}>
-              <Entypo name="user" size={tabBarIconWidth} color={color} />
+              <Entypo
+                name="user"
+                size={tabBarIconWidth}
+                color={focused ? theme.colors.WHITE : theme.colors.GRAY_300}
+              />
             </TabIconContainer>
           ),
         }}

--- a/src/screens/admin/user-detail/index.tsx
+++ b/src/screens/admin/user-detail/index.tsx
@@ -1,0 +1,273 @@
+import { Button } from "@components/button";
+import { CustomText } from "@components/custom-text";
+import { AccountCard } from "@components/account-card";
+import { AccountTransactionHistory } from "@components/account-transaction-history";
+import { CustomHeader } from "@components/custom-header";
+import { LinearGradientBackground } from "@components/LinearGradientBackground";
+import { RouteProp, useNavigation, useRoute } from "@react-navigation/native";
+import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import { StatusBar } from "expo-status-bar";
+import dayjs from "dayjs";
+import { ActivityIndicator } from "react-native";
+import { Dropdown } from "react-native-element-dropdown";
+import { formatToBRL } from "src/helpers/format-currency";
+import { AdminRoutes } from "src/routes/admin.routes";
+import theme from "src/styles/theme";
+import * as S from "./styles";
+import { RegisterPaymentModal } from "./register-payment-modal";
+import { useAdminUserDetail } from "./use-admin-user-detail";
+import { useRegisterPayment } from "./use-register-payment";
+
+type AdminUserDetailRouteParams = {
+  userDetail: {
+    userId: number;
+  };
+};
+
+export function AdminUserDetailScreen() {
+  const route = useRoute<RouteProp<AdminUserDetailRouteParams, "userDetail">>();
+  const navigation = useNavigation<NativeStackNavigationProp<AdminRoutes>>();
+  const { userId } = route.params;
+
+  const {
+    userDetail,
+    userAccounts,
+    transactions,
+    isLoading,
+    isLoadingAccounts,
+    isLoadingTransactions,
+    accountSort,
+    setAccountSort,
+    transactionSort,
+    setTransactionSort,
+    selectedAccountFilter,
+    setSelectedAccountFilter,
+    accountFilterOptions,
+    accountSortOptions,
+    transactionSortOptions,
+    hasMoreTransactions,
+    loadMoreTransactions,
+    reloadUserDetailScreen,
+  } = useAdminUserDetail(userId);
+
+  const {
+    isPaymentModalVisible,
+    openPaymentModal,
+    closePaymentModal,
+    submitPayment,
+    isSubmittingPayment,
+    hasOpenAccounts,
+    paymentAccountOptions,
+    paymentMethodOptions,
+    selectedPaymentAccountId,
+    handlePaymentAccountChange,
+    paymentAmountInput,
+    setPaymentAmountInput,
+    paymentMethod,
+    setPaymentMethod,
+    paymentNotes,
+    setPaymentNotes,
+  } = useRegisterPayment({
+    userAccounts,
+    onPaymentSuccess: reloadUserDetailScreen,
+  });
+
+  if (isLoading || !userDetail) {
+    return (
+      <LinearGradientBackground>
+        <S.SafeAreaViewContainer>
+          <StatusBar style="light" />
+          <CustomHeader />
+          <ActivityIndicator size="large" color={theme.colors.WHITE} />
+        </S.SafeAreaViewContainer>
+      </LinearGradientBackground>
+    );
+  }
+
+  const paidAccountsCount = userAccounts.filter(
+    (account) => account.payment_state === "PAGO"
+  ).length;
+
+  return (
+    <LinearGradientBackground>
+      <S.SafeAreaViewContainer>
+        <StatusBar style="light" />
+        <CustomHeader />
+        <S.ScrollViewContainer>
+          <S.ContentContainer>
+            <S.SummaryCard>
+              <S.SummaryTitle>{userDetail.username}</S.SummaryTitle>
+              <S.RowContainer>
+                <S.RowLabel>Saldo total em aberto</S.RowLabel>
+                <S.OpenBalanceValue>
+                  {formatToBRL(userDetail.accountSummary.openBalance)}
+                </S.OpenBalanceValue>
+              </S.RowContainer>
+              <S.RowContainer>
+                <S.RowLabel>Contas em aberto</S.RowLabel>
+                <S.RowValue>
+                  {userDetail.accountSummary.openAccountsCount}
+                </S.RowValue>
+              </S.RowContainer>
+              <S.RowContainer>
+                <S.RowLabel>Contas vencidas</S.RowLabel>
+                <S.RowValue>
+                  {userDetail.accountSummary.overdueAccountsCount}
+                </S.RowValue>
+              </S.RowContainer>
+              <S.RowContainer>
+                <S.RowLabel>Contas quitadas</S.RowLabel>
+                <S.RowValue>{paidAccountsCount}</S.RowValue>
+              </S.RowContainer>
+              {hasOpenAccounts && (
+                <Button color={theme.colors.GREEN} onPress={openPaymentModal}>
+                  <CustomText
+                    color={theme.colors.WHITE}
+                    fontWeight={theme.font.weight.bold}
+                  >
+                    Registrar pagamento
+                  </CustomText>
+                </Button>
+              )}
+            </S.SummaryCard>
+
+            <S.SectionCard>
+              <S.SectionTitleRow>
+                <S.SectionAccent />
+                <S.SectionTitle>Cliente</S.SectionTitle>
+              </S.SectionTitleRow>
+              <S.RowContainer>
+                <S.RowLabel>E-mail</S.RowLabel>
+                <S.RowValue>{userDetail.email}</S.RowValue>
+              </S.RowContainer>
+              <S.RowContainer>
+                <S.RowLabel>Telefone</S.RowLabel>
+                <S.RowValue>{userDetail.telephone}</S.RowValue>
+              </S.RowContainer>
+              <S.RowContainer>
+                <S.RowLabel>Cadastro</S.RowLabel>
+                <S.RowValue>
+                  {dayjs(userDetail.created_at).format("DD/MM/YYYY")}
+                </S.RowValue>
+              </S.RowContainer>
+              {userDetail.addresses.map((address) => (
+                <S.RowContainer key={address.id}>
+                  <S.RowLabel>Endereço</S.RowLabel>
+                  <S.RowValue>
+                    {[address.local, address.street, address.number]
+                      .filter(Boolean)
+                      .join(", ")}
+                  </S.RowValue>
+                </S.RowContainer>
+              ))}
+            </S.SectionCard>
+
+            <S.SectionCard>
+              <S.SectionTitleRow>
+                <S.SectionAccent />
+                <S.SectionTitle>Contas</S.SectionTitle>
+              </S.SectionTitleRow>
+              <S.SortControlShell>
+                <Dropdown
+                  style={S.dropdownStyles.dropdown}
+                  placeholderStyle={S.dropdownStyles.placeholder}
+                  selectedTextStyle={S.dropdownStyles.selectedText}
+                  iconStyle={S.dropdownStyles.icon}
+                  containerStyle={S.dropdownStyles.menuContainer}
+                  data={accountSortOptions}
+                  maxHeight={220}
+                  labelField="label"
+                  valueField="value"
+                  value={accountSort}
+                  onChange={({ value }) => setAccountSort(value)}
+                />
+              </S.SortControlShell>
+              {isLoadingAccounts ? (
+                <ActivityIndicator size="small" color={theme.colors.ORANGE_300} />
+              ) : (
+                <S.AccountsList>
+                  {userAccounts.map((account) => (
+                    <AccountCard
+                      key={account.id}
+                      account={account}
+                      onPress={() =>
+                        navigation.navigate("orderDetail", {
+                          orderId: account.id,
+                        })
+                      }
+                    />
+                  ))}
+                </S.AccountsList>
+              )}
+            </S.SectionCard>
+
+            <S.SectionCard>
+              <S.SectionTitleRow>
+                <S.SectionAccent />
+                <S.SectionTitle>Histórico de movimentações</S.SectionTitle>
+              </S.SectionTitleRow>
+              <S.SortControlShell>
+                <Dropdown
+                  style={S.dropdownStyles.dropdown}
+                  placeholderStyle={S.dropdownStyles.placeholder}
+                  selectedTextStyle={S.dropdownStyles.selectedText}
+                  iconStyle={S.dropdownStyles.icon}
+                  containerStyle={S.dropdownStyles.menuContainer}
+                  data={accountFilterOptions}
+                  maxHeight={220}
+                  labelField="label"
+                  valueField="value"
+                  value={selectedAccountFilter}
+                  onChange={({ value }) => setSelectedAccountFilter(value)}
+                />
+              </S.SortControlShell>
+              <S.SortControlShell>
+                <Dropdown
+                  style={S.dropdownStyles.dropdown}
+                  placeholderStyle={S.dropdownStyles.placeholder}
+                  selectedTextStyle={S.dropdownStyles.selectedText}
+                  iconStyle={S.dropdownStyles.icon}
+                  containerStyle={S.dropdownStyles.menuContainer}
+                  data={transactionSortOptions}
+                  maxHeight={220}
+                  labelField="label"
+                  valueField="value"
+                  value={transactionSort}
+                  onChange={({ value }) => setTransactionSort(value)}
+                />
+              </S.SortControlShell>
+              {isLoadingTransactions && transactions.length === 0 ? (
+                <ActivityIndicator size="small" color={theme.colors.ORANGE_300} />
+              ) : (
+                <AccountTransactionHistory transactions={transactions} />
+              )}
+              {hasMoreTransactions && !isLoadingTransactions && (
+                <S.LoadMoreButton onPress={loadMoreTransactions}>
+                  <S.LoadMoreButtonText>
+                    Carregar mais movimentações
+                  </S.LoadMoreButtonText>
+                </S.LoadMoreButton>
+              )}
+            </S.SectionCard>
+          </S.ContentContainer>
+        </S.ScrollViewContainer>
+        <RegisterPaymentModal
+          visible={isPaymentModalVisible}
+          isSubmittingPayment={isSubmittingPayment}
+          paymentAccountOptions={paymentAccountOptions}
+          paymentMethodOptions={paymentMethodOptions}
+          selectedPaymentAccountId={selectedPaymentAccountId}
+          paymentAmountInput={paymentAmountInput}
+          paymentMethod={paymentMethod}
+          paymentNotes={paymentNotes}
+          onClose={closePaymentModal}
+          onSubmit={submitPayment}
+          onPaymentAccountChange={handlePaymentAccountChange}
+          onPaymentAmountChange={setPaymentAmountInput}
+          onPaymentMethodChange={setPaymentMethod}
+          onPaymentNotesChange={setPaymentNotes}
+        />
+      </S.SafeAreaViewContainer>
+    </LinearGradientBackground>
+  );
+}

--- a/src/screens/admin/user-detail/register-payment-modal/index.tsx
+++ b/src/screens/admin/user-detail/register-payment-modal/index.tsx
@@ -1,0 +1,135 @@
+import { Button } from "@components/button";
+import { CustomText } from "@components/custom-text";
+import { PaymentMethod } from "src/services/transactions/types";
+import { Modal, Pressable } from "react-native";
+import { Dropdown } from "react-native-element-dropdown";
+import theme from "src/styles/theme";
+import * as S from "./styles";
+
+type PaymentAccountOption = {
+  label: string;
+  value: number;
+};
+
+type PaymentMethodOption = {
+  label: string;
+  value: PaymentMethod;
+};
+
+type RegisterPaymentModalProps = {
+  visible: boolean;
+  isSubmittingPayment: boolean;
+  paymentAccountOptions: PaymentAccountOption[];
+  paymentMethodOptions: PaymentMethodOption[];
+  selectedPaymentAccountId: number | null;
+  paymentAmountInput: string;
+  paymentMethod: PaymentMethod | null;
+  paymentNotes: string;
+  onClose: () => void;
+  onSubmit: () => void;
+  onPaymentAccountChange: (accountId: number) => void;
+  onPaymentAmountChange: (amount: string) => void;
+  onPaymentMethodChange: (method: PaymentMethod) => void;
+  onPaymentNotesChange: (notes: string) => void;
+};
+
+export function RegisterPaymentModal({
+  visible,
+  isSubmittingPayment,
+  paymentAccountOptions,
+  paymentMethodOptions,
+  selectedPaymentAccountId,
+  paymentAmountInput,
+  paymentMethod,
+  paymentNotes,
+  onClose,
+  onSubmit,
+  onPaymentAccountChange,
+  onPaymentAmountChange,
+  onPaymentMethodChange,
+  onPaymentNotesChange,
+}: RegisterPaymentModalProps) {
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={onClose}
+    >
+      <S.ModalOverlay>
+        <Pressable style={{ flex: 1 }} onPress={onClose} />
+        <S.ModalContent>
+          <S.ModalTitle>Registrar pagamento</S.ModalTitle>
+
+          <S.FieldLabel>Conta</S.FieldLabel>
+          <S.SortControlShell>
+            <Dropdown
+              style={S.dropdownStyles.dropdown}
+              placeholderStyle={S.dropdownStyles.placeholder}
+              selectedTextStyle={S.dropdownStyles.selectedText}
+              iconStyle={S.dropdownStyles.icon}
+              containerStyle={S.dropdownStyles.menuContainer}
+              data={paymentAccountOptions}
+              maxHeight={220}
+              labelField="label"
+              valueField="value"
+              value={selectedPaymentAccountId}
+              onChange={({ value }) => onPaymentAccountChange(value)}
+            />
+          </S.SortControlShell>
+
+          <S.FieldLabel>Valor</S.FieldLabel>
+          <S.FieldInput
+            value={paymentAmountInput}
+            onChangeText={onPaymentAmountChange}
+            keyboardType="decimal-pad"
+            placeholder="0,00"
+            placeholderTextColor={theme.colors.GRAY_300}
+          />
+
+          <S.FieldLabel>Método de pagamento</S.FieldLabel>
+          <S.SortControlShell>
+            <Dropdown
+              style={S.dropdownStyles.dropdown}
+              placeholderStyle={S.dropdownStyles.placeholder}
+              selectedTextStyle={S.dropdownStyles.selectedText}
+              iconStyle={S.dropdownStyles.icon}
+              containerStyle={S.dropdownStyles.menuContainer}
+              data={paymentMethodOptions}
+              maxHeight={220}
+              labelField="label"
+              valueField="value"
+              value={paymentMethod}
+              onChange={({ value }) => onPaymentMethodChange(value)}
+            />
+          </S.SortControlShell>
+
+          <S.FieldLabel>Observações</S.FieldLabel>
+          <S.NotesInput
+            value={paymentNotes}
+            onChangeText={onPaymentNotesChange}
+            placeholder="Opcional"
+            placeholderTextColor={theme.colors.GRAY_300}
+            multiline
+          />
+
+          <S.ModalActionsRow>
+            <S.CancelButton onPress={onClose} disabled={isSubmittingPayment}>
+              <S.CancelButtonText>Cancelar</S.CancelButtonText>
+            </S.CancelButton>
+            <Button
+              color={theme.colors.GREEN}
+              isLoading={isSubmittingPayment}
+              onPress={onSubmit}
+              style={{ flex: 1, marginBottom: 0 }}
+            >
+              <CustomText color={theme.colors.WHITE} fontWeight={theme.font.weight.bold}>
+                Confirmar
+              </CustomText>
+            </Button>
+          </S.ModalActionsRow>
+        </S.ModalContent>
+      </S.ModalOverlay>
+    </Modal>
+  );
+}

--- a/src/screens/admin/user-detail/register-payment-modal/styles.ts
+++ b/src/screens/admin/user-detail/register-payment-modal/styles.ts
@@ -1,0 +1,105 @@
+import theme from "src/styles/theme";
+import styled from "styled-components/native";
+import { StyleSheet } from "react-native";
+
+export const ModalOverlay = styled.View`
+  flex: 1;
+  background-color: rgba(0, 0, 0, 0.5);
+  justify-content: flex-end;
+`;
+
+export const ModalContent = styled.View`
+  background-color: ${theme.colors.WHITE};
+  border-top-left-radius: 20px;
+  border-top-right-radius: 20px;
+  padding: ${theme.size.m6};
+  gap: ${theme.size.m4};
+  max-height: 90%;
+`;
+
+export const ModalTitle = styled.Text`
+  color: ${theme.colors.GRAY_600};
+  font-size: ${theme.font.size.m6};
+  font-weight: ${theme.font.weight.bold};
+`;
+
+export const FieldLabel = styled.Text`
+  color: ${theme.colors.GRAY_300};
+  font-size: ${theme.font.size.m4};
+  font-weight: ${theme.font.weight.semibold};
+`;
+
+export const FieldInput = styled.TextInput`
+  height: 50px;
+  border-radius: 10px;
+  background-color: ${theme.colors.GRAY_100};
+  padding-horizontal: 16px;
+  font-size: 16px;
+  font-weight: bold;
+  color: ${theme.colors.GRAY_600};
+`;
+
+export const NotesInput = styled.TextInput`
+  min-height: 80px;
+  border-radius: 10px;
+  background-color: ${theme.colors.GRAY_100};
+  padding: 16px;
+  font-size: 16px;
+  color: ${theme.colors.GRAY_600};
+  text-align-vertical: top;
+`;
+
+export const SortControlShell = styled.View`
+  min-height: 50px;
+  border-radius: 10px;
+  background-color: ${theme.colors.GRAY_100};
+  padding-horizontal: 12px;
+  justify-content: center;
+`;
+
+export const ModalActionsRow = styled.View`
+  flex-direction: row;
+  gap: ${theme.size.m3};
+`;
+
+export const CancelButton = styled.TouchableOpacity`
+  flex: 1;
+  height: 50px;
+  border-radius: 12px;
+  background-color: ${theme.colors.GRAY_200};
+  align-items: center;
+  justify-content: center;
+`;
+
+export const CancelButtonText = styled.Text`
+  color: ${theme.colors.GRAY_600};
+  font-size: ${theme.font.size.m4};
+  font-weight: ${theme.font.weight.bold};
+`;
+
+export const dropdownStyles = StyleSheet.create({
+  dropdown: {
+    height: 50,
+  },
+  placeholder: {
+    fontSize: 16,
+    color: theme.colors.GRAY_300,
+    fontWeight: "bold",
+  },
+  selectedText: {
+    fontSize: 16,
+    fontWeight: "bold",
+    color: theme.colors.GRAY_600,
+  },
+  icon: {
+    width: 20,
+    height: 20,
+  },
+  menuContainer: {
+    borderRadius: 12,
+    backgroundColor: theme.colors.WHITE,
+    marginTop: 6,
+    paddingVertical: 4,
+    elevation: 8,
+  },
+});

--- a/src/screens/admin/user-detail/styles.ts
+++ b/src/screens/admin/user-detail/styles.ts
@@ -1,0 +1,145 @@
+import theme from "src/styles/theme";
+import styled from "styled-components/native";
+import { StyleSheet } from "react-native";
+
+export const SafeAreaViewContainer = styled.View`
+  flex: 1;
+  padding: ${theme.size.m7};
+`;
+
+export const ScrollViewContainer = styled.ScrollView.attrs({
+  contentContainerStyle: {
+    flexGrow: 1,
+    paddingBottom: 40,
+  },
+  showsVerticalScrollIndicator: false,
+})`
+  flex: 1;
+  width: 100%;
+`;
+
+export const ContentContainer = styled.View`
+  gap: ${theme.size.m5};
+  width: 100%;
+  padding-top: ${theme.size.m4};
+`;
+
+export const SectionCard = styled.View`
+  background-color: ${theme.colors.WHITE};
+  border-radius: 12px;
+  padding: ${theme.size.m5};
+  gap: ${theme.size.m3};
+  elevation: 4;
+  shadow-color: #000;
+  shadow-opacity: 0.08;
+  shadow-radius: 6px;
+  shadow-offset: 0px 2px;
+`;
+
+export const SummaryCard = styled(SectionCard)`
+  border-top-width: 4px;
+  border-top-color: ${theme.colors.ORANGE_300};
+`;
+
+export const SectionTitleRow = styled.View`
+  flex-direction: row;
+  align-items: center;
+  gap: ${theme.size.m2};
+`;
+
+export const SectionAccent = styled.View`
+  width: 4px;
+  height: 18px;
+  border-radius: 2px;
+  background-color: ${theme.colors.ORANGE_300};
+`;
+
+export const SectionTitle = styled.Text`
+  color: ${theme.colors.GRAY_600};
+  font-size: ${theme.font.size.m5};
+  font-weight: ${theme.font.weight.bold};
+`;
+
+export const RowContainer = styled.View`
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  gap: ${theme.size.m3};
+`;
+
+export const RowLabel = styled.Text`
+  color: ${theme.colors.GRAY_300};
+  font-size: ${theme.font.size.m4};
+  font-weight: ${theme.font.weight.semibold};
+  flex: 1;
+`;
+
+export const RowValue = styled.Text`
+  color: ${theme.colors.GRAY_600};
+  font-size: ${theme.font.size.m4};
+  font-weight: ${theme.font.weight.bold};
+  flex: 1;
+  text-align: right;
+`;
+
+export const SummaryTitle = styled.Text`
+  color: ${theme.colors.GRAY_600};
+  font-size: ${theme.font.size.m7};
+  font-weight: ${theme.font.weight.extrabold};
+`;
+
+export const OpenBalanceValue = styled.Text`
+  color: ${theme.colors.ORANGE_300};
+  font-size: ${theme.font.size.m8};
+  font-weight: ${theme.font.weight.extrabold};
+`;
+
+export const AccountsList = styled.View`
+  gap: ${theme.size.m3};
+`;
+
+export const SortControlShell = styled.View`
+  min-height: 50px;
+  border-radius: 10px;
+  background-color: ${theme.colors.GRAY_100};
+  padding-horizontal: 12px;
+  justify-content: center;
+`;
+
+export const LoadMoreButton = styled.TouchableOpacity`
+  align-self: center;
+  padding: ${theme.size.m3} ${theme.size.m5};
+`;
+
+export const LoadMoreButtonText = styled.Text`
+  color: ${theme.colors.WHITE};
+  font-size: ${theme.font.size.m4};
+  font-weight: ${theme.font.weight.bold};
+`;
+
+export const dropdownStyles = StyleSheet.create({
+  dropdown: {
+    height: 50,
+  },
+  placeholder: {
+    fontSize: 16,
+    color: theme.colors.GRAY_300,
+    fontWeight: "bold",
+  },
+  selectedText: {
+    fontSize: 16,
+    fontWeight: "bold",
+    color: theme.colors.GRAY_600,
+  },
+  icon: {
+    width: 20,
+    height: 20,
+  },
+  menuContainer: {
+    borderRadius: 12,
+    backgroundColor: theme.colors.WHITE,
+    marginTop: 6,
+    paddingVertical: 4,
+    elevation: 8,
+  },
+});

--- a/src/screens/admin/user-detail/use-admin-user-detail.ts
+++ b/src/screens/admin/user-detail/use-admin-user-detail.ts
@@ -1,0 +1,197 @@
+import { useFocusEffect } from "@react-navigation/native";
+import { useCallback, useEffect, useState } from "react";
+import Toast from "react-native-toast-message";
+import { getUserTransactions } from "src/services/transactions";
+import {
+  TransactionSortOption,
+  UserAccountTransactionHistoryItem,
+} from "src/services/transactions/types";
+import { getUserAccounts, getUserById } from "src/services/user";
+import {
+  AccountSortOption,
+  AdminUserListItem,
+  UserAccountProps,
+} from "src/services/user/types";
+
+const transactionsPageSize = 20;
+
+export function useAdminUserDetail(userId: number) {
+  const [userDetail, setUserDetail] = useState<AdminUserListItem | null>(null);
+  const [userAccounts, setUserAccounts] = useState<UserAccountProps[]>([]);
+  const [transactions, setTransactions] = useState<
+    UserAccountTransactionHistoryItem[]
+  >([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingAccounts, setIsLoadingAccounts] = useState(false);
+  const [isLoadingTransactions, setIsLoadingTransactions] = useState(false);
+  const [accountSort, setAccountSort] = useState<AccountSortOption>("open_first");
+  const [transactionSort, setTransactionSort] =
+    useState<TransactionSortOption>("date_desc");
+  const [selectedAccountFilter, setSelectedAccountFilter] = useState<
+    number | "all"
+  >("all");
+  const [transactionsPage, setTransactionsPage] = useState(1);
+  const [hasMoreTransactions, setHasMoreTransactions] = useState(true);
+
+  const loadUserDetail = useCallback(async () => {
+    try {
+      const user = await getUserById(userId);
+      setUserDetail(user);
+    } catch (error: any) {
+      const errorMessage =
+        error.response?.data?.message ?? error.message ?? "tente novamente";
+      Toast.show({
+        type: "error",
+        text2: `Erro ${errorMessage.toLowerCase()}`,
+      });
+    }
+  }, [userId]);
+
+  const loadUserAccounts = useCallback(async () => {
+    setIsLoadingAccounts(true);
+
+    try {
+      const accounts = await getUserAccounts({
+        userId,
+        sort: accountSort,
+      });
+      setUserAccounts(accounts);
+    } catch (error: any) {
+      const errorMessage =
+        error.response?.data?.message ?? error.message ?? "tente novamente";
+      Toast.show({
+        type: "error",
+        text2: `Erro ${errorMessage.toLowerCase()}`,
+      });
+    } finally {
+      setIsLoadingAccounts(false);
+    }
+  }, [accountSort, userId]);
+
+  const loadTransactionsPage = useCallback(
+    async (pageNumber: number, shouldAppend: boolean) => {
+      setIsLoadingTransactions(true);
+
+      try {
+        const transactionsResponse = await getUserTransactions({
+          userId,
+          page: pageNumber,
+          limit: transactionsPageSize,
+          sort: transactionSort,
+          orderId:
+            selectedAccountFilter === "all"
+              ? undefined
+              : selectedAccountFilter,
+        });
+
+        setTransactions((previousTransactions) =>
+          shouldAppend
+            ? [...previousTransactions, ...transactionsResponse.items]
+            : transactionsResponse.items
+        );
+        setTransactionsPage(pageNumber);
+        setHasMoreTransactions(
+          pageNumber < transactionsResponse.pagination.totalPages
+        );
+      } catch (error: any) {
+        const errorMessage =
+          error.response?.data?.message ?? error.message ?? "tente novamente";
+        Toast.show({
+          type: "error",
+          text2: `Erro ${errorMessage.toLowerCase()}`,
+        });
+      } finally {
+        setIsLoadingTransactions(false);
+      }
+    },
+    [selectedAccountFilter, transactionSort, userId]
+  );
+
+  const reloadTransactions = useCallback(async () => {
+    setHasMoreTransactions(true);
+    await loadTransactionsPage(1, false);
+  }, [loadTransactionsPage]);
+
+  const loadMoreTransactions = useCallback(async () => {
+    if (!hasMoreTransactions || isLoadingTransactions) {
+      return;
+    }
+
+    await loadTransactionsPage(transactionsPage + 1, true);
+  }, [
+    hasMoreTransactions,
+    isLoadingTransactions,
+    loadTransactionsPage,
+    transactionsPage,
+  ]);
+
+  const reloadUserDetailScreen = useCallback(async () => {
+    setIsLoading(true);
+
+    await Promise.all([
+      loadUserDetail(),
+      loadUserAccounts(),
+      reloadTransactions(),
+    ]);
+
+    setIsLoading(false);
+  }, [loadUserAccounts, loadUserDetail, reloadTransactions]);
+
+  useFocusEffect(
+    useCallback(() => {
+      reloadUserDetailScreen();
+    }, [reloadUserDetailScreen])
+  );
+
+  useEffect(() => {
+    loadUserAccounts();
+  }, [loadUserAccounts]);
+
+  useEffect(() => {
+    reloadTransactions();
+  }, [reloadTransactions]);
+
+  const accountFilterOptions = [
+    { label: "Todas as contas", value: "all" as const },
+    ...userAccounts.map((account) => ({
+      label: `Conta #${account.id}`,
+      value: account.id,
+    })),
+  ];
+
+  const accountSortOptions = [
+    { label: "Em aberto primeiro", value: "open_first" as AccountSortOption },
+    { label: "Mais recentes", value: "date_desc" as AccountSortOption },
+    { label: "Mais antigas", value: "date_asc" as AccountSortOption },
+    { label: "Maior saldo", value: "balance_desc" as AccountSortOption },
+    { label: "Menor saldo", value: "balance_asc" as AccountSortOption },
+  ];
+
+  const transactionSortOptions = [
+    { label: "Mais recentes", value: "date_desc" as TransactionSortOption },
+    { label: "Mais antigas", value: "date_asc" as TransactionSortOption },
+    { label: "Maior valor", value: "amount_desc" as TransactionSortOption },
+    { label: "Menor valor", value: "amount_asc" as TransactionSortOption },
+  ];
+
+  return {
+    userDetail,
+    userAccounts,
+    transactions,
+    isLoading,
+    isLoadingAccounts,
+    isLoadingTransactions,
+    accountSort,
+    setAccountSort,
+    transactionSort,
+    setTransactionSort,
+    selectedAccountFilter,
+    setSelectedAccountFilter,
+    accountFilterOptions,
+    accountSortOptions,
+    transactionSortOptions,
+    hasMoreTransactions,
+    loadMoreTransactions,
+    reloadUserDetailScreen,
+  };
+}

--- a/src/screens/admin/user-detail/use-admin-user-detail.ts
+++ b/src/screens/admin/user-detail/use-admin-user-detail.ts
@@ -24,7 +24,7 @@ export function useAdminUserDetail(userId: number) {
   const [isLoading, setIsLoading] = useState(true);
   const [isLoadingAccounts, setIsLoadingAccounts] = useState(false);
   const [isLoadingTransactions, setIsLoadingTransactions] = useState(false);
-  const [accountSort, setAccountSort] = useState<AccountSortOption>("open_first");
+  const [accountSort, setAccountSort] = useState<AccountSortOption>("unpaid_first");
   const [transactionSort, setTransactionSort] =
     useState<TransactionSortOption>("date_desc");
   const [selectedAccountFilter, setSelectedAccountFilter] = useState<
@@ -160,7 +160,7 @@ export function useAdminUserDetail(userId: number) {
   ];
 
   const accountSortOptions = [
-    { label: "Em aberto primeiro", value: "open_first" as AccountSortOption },
+    { label: "Em aberto primeiro", value: "unpaid_first" as AccountSortOption },
     { label: "Mais recentes", value: "date_desc" as AccountSortOption },
     { label: "Mais antigas", value: "date_asc" as AccountSortOption },
     { label: "Maior saldo", value: "balance_desc" as AccountSortOption },

--- a/src/screens/admin/user-detail/use-register-payment.ts
+++ b/src/screens/admin/user-detail/use-register-payment.ts
@@ -1,0 +1,193 @@
+import { useCallback, useMemo, useState } from "react";
+import Toast from "react-native-toast-message";
+import { registerPayment } from "src/services/transactions";
+import { PaymentMethod } from "src/services/transactions/types";
+import { formatToBRL } from "src/helpers/format-currency";
+import { isOpenAccount } from "src/helpers/payment-state";
+import { UserAccountProps } from "src/services/user/types";
+
+function parsePaymentAmountInput(amountInput: string) {
+  const normalizedAmount = amountInput.replace(",", ".").trim();
+  return Number(normalizedAmount);
+}
+
+type UseRegisterPaymentParams = {
+  userAccounts: UserAccountProps[];
+  onPaymentSuccess: () => Promise<void>;
+};
+
+export function useRegisterPayment({
+  userAccounts,
+  onPaymentSuccess,
+}: UseRegisterPaymentParams) {
+  const [isPaymentModalVisible, setIsPaymentModalVisible] = useState(false);
+  const [selectedPaymentAccountId, setSelectedPaymentAccountId] = useState<
+    number | null
+  >(null);
+  const [paymentAmountInput, setPaymentAmountInput] = useState("");
+  const [paymentMethod, setPaymentMethod] = useState<PaymentMethod | null>(
+    null
+  );
+  const [paymentNotes, setPaymentNotes] = useState("");
+  const [isSubmittingPayment, setIsSubmittingPayment] = useState(false);
+
+  const openAccounts = useMemo(
+    () => userAccounts.filter((account) => isOpenAccount(account.payment_state)),
+    [userAccounts]
+  );
+
+  const paymentAccountOptions = useMemo(
+    () =>
+      openAccounts.map((account) => ({
+        label: `Conta #${account.id} — saldo ${formatToBRL(account.total)}`,
+        value: account.id,
+        balance: account.total,
+      })),
+    [openAccounts]
+  );
+
+  const paymentMethodOptions = useMemo(
+    () => [
+      { label: "Dinheiro", value: "DINHEIRO" as PaymentMethod },
+      { label: "PIX", value: "PIX" as PaymentMethod },
+      { label: "Cartão", value: "CARTAO" as PaymentMethod },
+      { label: "Transferência", value: "TRANSFERENCIA" as PaymentMethod },
+    ],
+    []
+  );
+
+  const selectedPaymentAccount = openAccounts.find(
+    (account) => account.id === selectedPaymentAccountId
+  );
+
+  const resetPaymentForm = useCallback(() => {
+    setSelectedPaymentAccountId(null);
+    setPaymentAmountInput("");
+    setPaymentMethod(null);
+    setPaymentNotes("");
+  }, []);
+
+  const openPaymentModal = useCallback(() => {
+    const firstOpenAccount = openAccounts[0];
+
+    if (!firstOpenAccount) {
+      Toast.show({
+        type: "error",
+        text2: "Não há contas em aberto para registrar pagamento",
+      });
+      return;
+    }
+
+    setSelectedPaymentAccountId(firstOpenAccount.id);
+    setPaymentAmountInput(String(firstOpenAccount.total));
+    setPaymentMethod("DINHEIRO");
+    setPaymentNotes("");
+    setIsPaymentModalVisible(true);
+  }, [openAccounts]);
+
+  const closePaymentModal = useCallback(() => {
+    setIsPaymentModalVisible(false);
+    resetPaymentForm();
+  }, [resetPaymentForm]);
+
+  const handlePaymentAccountChange = useCallback(
+    (accountId: number) => {
+      const selectedAccount = openAccounts.find(
+        (account) => account.id === accountId
+      );
+
+      setSelectedPaymentAccountId(accountId);
+
+      if (selectedAccount) {
+        setPaymentAmountInput(String(selectedAccount.total));
+      }
+    },
+    [openAccounts]
+  );
+
+  const submitPayment = useCallback(async () => {
+    if (!selectedPaymentAccountId || !paymentMethod) {
+      Toast.show({
+        type: "error",
+        text2: "Selecione a conta e o método de pagamento",
+      });
+      return;
+    }
+
+    const paymentAmount = parsePaymentAmountInput(paymentAmountInput);
+
+    if (!paymentAmount || paymentAmount <= 0) {
+      Toast.show({
+        type: "error",
+        text2: "Informe um valor válido para o pagamento",
+      });
+      return;
+    }
+
+    if (
+      selectedPaymentAccount &&
+      paymentAmount > selectedPaymentAccount.total
+    ) {
+      Toast.show({
+        type: "error",
+        text2: "O valor não pode ser maior que o saldo da conta",
+      });
+      return;
+    }
+
+    setIsSubmittingPayment(true);
+
+    try {
+      await registerPayment({
+        order_id: selectedPaymentAccountId,
+        amount_paid: paymentAmount,
+        payment_method: paymentMethod,
+        notes: paymentNotes.trim() || undefined,
+      });
+
+      Toast.show({
+        type: "success",
+        text2: "Pagamento registrado com sucesso",
+      });
+
+      closePaymentModal();
+      await onPaymentSuccess();
+    } catch (error: any) {
+      const errorMessage =
+        error.response?.data?.message ?? error.message ?? "tente novamente";
+      Toast.show({
+        type: "error",
+        text2: `Erro ${errorMessage.toLowerCase()}`,
+      });
+    } finally {
+      setIsSubmittingPayment(false);
+    }
+  }, [
+    closePaymentModal,
+    onPaymentSuccess,
+    paymentAmountInput,
+    paymentMethod,
+    paymentNotes,
+    selectedPaymentAccount,
+    selectedPaymentAccountId,
+  ]);
+
+  return {
+    isPaymentModalVisible,
+    openPaymentModal,
+    closePaymentModal,
+    submitPayment,
+    isSubmittingPayment,
+    hasOpenAccounts: openAccounts.length > 0,
+    paymentAccountOptions,
+    paymentMethodOptions,
+    selectedPaymentAccountId,
+    handlePaymentAccountChange,
+    paymentAmountInput,
+    setPaymentAmountInput,
+    paymentMethod,
+    setPaymentMethod,
+    paymentNotes,
+    setPaymentNotes,
+  };
+}

--- a/src/screens/admin/users-list/index.tsx
+++ b/src/screens/admin/users-list/index.tsx
@@ -1,0 +1,79 @@
+import { LinearGradientBackground } from "@components/LinearGradientBackground";
+import { UserCard } from "@components/user-card";
+import { UsersList } from "@components/users-list";
+import { Feather } from "@expo/vector-icons";
+import { useNavigation } from "@react-navigation/native";
+import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import { AdminRoutes } from "src/routes/admin.routes";
+import theme from "src/styles/theme";
+import * as S from "./styles";
+import { useAdminUsersList } from "./use-admin-users-list";
+
+type UserDetailNavigationProp = NativeStackNavigationProp<AdminRoutes>;
+
+export function AdminUsersListScreen() {
+  const navigation = useNavigation<UserDetailNavigationProp>();
+  const {
+    users,
+    searchTerm,
+    setSearchTerm,
+    refreshing,
+    loadError,
+    reloadUsersList,
+    loadNextUsersPage,
+  } = useAdminUsersList();
+
+  return (
+    <LinearGradientBackground>
+      <S.Container>
+        <S.SearchContainer>
+          <S.SearchInputShell>
+            <Feather
+              name="search"
+              size={20}
+              color={theme.colors.GRAY_300}
+            />
+            <S.SearchInput
+              value={searchTerm}
+              onChangeText={setSearchTerm}
+              placeholder="Buscar por nome ou telefone"
+              placeholderTextColor={theme.colors.GRAY_300}
+              returnKeyType="search"
+            />
+            {searchTerm.length > 0 && (
+              <S.ClearSearchButton onPress={() => setSearchTerm("")}>
+                <Feather
+                  name="x"
+                  size={18}
+                  color={theme.colors.GRAY_400}
+                />
+              </S.ClearSearchButton>
+            )}
+          </S.SearchInputShell>
+        </S.SearchContainer>
+        <UsersList
+          users={users}
+          refreshing={refreshing}
+          onRefresh={reloadUsersList}
+          onEndList={loadNextUsersPage}
+          emptyListMessage={
+            loadError
+              ? "Não foi possível carregar os clientes. Verifique se o servidor está rodando e puxe para atualizar."
+              : "Não há clientes cadastrados"
+          }
+          itemSeparatorComponent={S.Divider}
+          renderItem={({ item }) => (
+            <UserCard
+              username={item.username}
+              telephone={item.telephone}
+              accountSummary={item.accountSummary}
+              onPress={() =>
+                navigation.navigate("userDetail", { userId: item.id })
+              }
+            />
+          )}
+        />
+      </S.Container>
+    </LinearGradientBackground>
+  );
+}

--- a/src/screens/admin/users-list/styles.ts
+++ b/src/screens/admin/users-list/styles.ts
@@ -1,0 +1,49 @@
+import theme from "src/styles/theme";
+import styled from "styled-components/native";
+
+export const Container = styled.View`
+  padding-horizontal: ${theme.size.m3};
+  flex: 1;
+`;
+
+export const Divider = styled.View`
+  height: 10px;
+`;
+
+export const SearchContainer = styled.View`
+  width: 100%;
+  margin-top: ${theme.size.m11};
+  margin-bottom: ${theme.size.m4};
+`;
+
+export const SearchInputShell = styled.View`
+  flex-direction: row;
+  align-items: center;
+  height: 50px;
+  border-radius: 12px;
+  background-color: ${theme.colors.WHITE};
+  padding-horizontal: ${theme.size.m4};
+  gap: ${theme.size.m3};
+  elevation: 5;
+  shadow-color: #000;
+  shadow-opacity: 0.1;
+  shadow-radius: 5px;
+  shadow-offset: 2px 2px;
+`;
+
+export const SearchInput = styled.TextInput`
+  flex: 1;
+  height: 50px;
+  font-size: ${theme.font.size.m4};
+  font-weight: ${theme.font.weight.semibold};
+  color: ${theme.colors.GRAY_600};
+`;
+
+export const ClearSearchButton = styled.TouchableOpacity`
+  width: 28px;
+  height: 28px;
+  border-radius: 14px;
+  background-color: ${theme.colors.GRAY_100};
+  align-items: center;
+  justify-content: center;
+`;

--- a/src/screens/admin/users-list/use-admin-users-list.ts
+++ b/src/screens/admin/users-list/use-admin-users-list.ts
@@ -1,0 +1,96 @@
+import { useFocusEffect } from "@react-navigation/native";
+import { useCallback, useEffect, useState } from "react";
+import Toast from "react-native-toast-message";
+import { getUsersList } from "src/services/user";
+import { AdminUserListItem } from "src/services/user/types";
+
+const pageSize = 10;
+const searchDebounceMilliseconds = 500;
+
+export function useAdminUsersList() {
+  const [users, setUsers] = useState<AdminUserListItem[]>([]);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [debouncedSearchTerm, setDebouncedSearchTerm] = useState("");
+  const [refreshing, setRefreshing] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [hasMoreUsers, setHasMoreUsers] = useState(true);
+
+  useEffect(() => {
+    const debounceTimer = setTimeout(() => {
+      setDebouncedSearchTerm(searchTerm.trim());
+    }, searchDebounceMilliseconds);
+
+    return () => clearTimeout(debounceTimer);
+  }, [searchTerm]);
+
+  const loadUsersPage = useCallback(
+    async (pageNumber: number, shouldAppend: boolean) => {
+      setRefreshing(true);
+
+      try {
+        const usersListResponse = await getUsersList({
+          page: pageNumber,
+          limit: pageSize,
+          search: debouncedSearchTerm || undefined,
+          sort: "open_first",
+        });
+
+        setUsers((previousUsers) =>
+          shouldAppend
+            ? [...previousUsers, ...usersListResponse.users]
+            : usersListResponse.users
+        );
+        setCurrentPage(pageNumber);
+        setHasMoreUsers(pageNumber < usersListResponse.totalPages);
+        setLoadError(null);
+      } catch (error: any) {
+        const errorMessage =
+          error.response?.data?.message ??
+          error.message ??
+          "tente novamente";
+        setLoadError(errorMessage);
+        Toast.show({
+          type: "error",
+          text2: `Erro ${errorMessage.toLowerCase()}`,
+        });
+      } finally {
+        setRefreshing(false);
+      }
+    },
+    [debouncedSearchTerm]
+  );
+
+  const reloadUsersList = useCallback(async () => {
+    setHasMoreUsers(true);
+    await loadUsersPage(1, false);
+  }, [loadUsersPage]);
+
+  const loadNextUsersPage = useCallback(async () => {
+    if (!hasMoreUsers || refreshing || users.length === 0) {
+      return;
+    }
+
+    await loadUsersPage(currentPage + 1, true);
+  }, [currentPage, hasMoreUsers, loadUsersPage, refreshing, users.length]);
+
+  useFocusEffect(
+    useCallback(() => {
+      reloadUsersList();
+    }, [reloadUsersList])
+  );
+
+  useEffect(() => {
+    reloadUsersList();
+  }, [debouncedSearchTerm, reloadUsersList]);
+
+  return {
+    users,
+    searchTerm,
+    setSearchTerm,
+    refreshing,
+    loadError,
+    reloadUsersList,
+    loadNextUsersPage,
+  };
+}

--- a/src/screens/admin/users-list/use-admin-users-list.ts
+++ b/src/screens/admin/users-list/use-admin-users-list.ts
@@ -33,7 +33,7 @@ export function useAdminUsersList() {
           page: pageNumber,
           limit: pageSize,
           search: debouncedSearchTerm || undefined,
-          sort: "open_first",
+          sort: "highest_debt_first",
         });
 
         setUsers((previousUsers) =>

--- a/src/services/transactions/index.ts
+++ b/src/services/transactions/index.ts
@@ -1,0 +1,35 @@
+import api from "@libs/axios/api";
+
+import {
+  GetUserTransactionsParams,
+  PaginatedTransactionsResponse,
+  RegisterPaymentPayload,
+  RegisterPaymentResponse,
+} from "./types";
+
+export const getUserTransactions = async ({
+  userId,
+  page = 1,
+  limit = 20,
+  sort = "date_desc",
+  orderId,
+}: GetUserTransactionsParams): Promise<PaginatedTransactionsResponse> => {
+  return api
+    .get(`/users/${userId}/transactions`, {
+      params: {
+        page,
+        limit,
+        sort,
+        order_id: orderId,
+      },
+    })
+    .then((response) => response.data);
+};
+
+export const registerPayment = async (
+  paymentPayload: RegisterPaymentPayload
+): Promise<RegisterPaymentResponse> => {
+  return api
+    .post("/transactions", paymentPayload)
+    .then((response) => response.data);
+};

--- a/src/services/transactions/types.ts
+++ b/src/services/transactions/types.ts
@@ -1,0 +1,59 @@
+import { OrderPaymentStatus } from "src/types/orders";
+
+export type TransactionSortOption =
+  | "date_desc"
+  | "date_asc"
+  | "amount_desc"
+  | "amount_asc";
+
+export type PaymentMethod = "DINHEIRO" | "PIX" | "CARTAO" | "TRANSFERENCIA";
+
+export type UserAccountTransactionHistoryItem = {
+  id: number;
+  order_id: number;
+  type: "PAYMENT" | "INTEREST" | "ADJUSTMENT";
+  amount: number;
+  old_value: number;
+  new_value: number;
+  payment_method?: PaymentMethod;
+  notes?: string;
+  created_at: string;
+  updated_at: string;
+  accountPaymentState: OrderPaymentStatus;
+};
+
+export type PaginatedTransactionsResponse = {
+  items: UserAccountTransactionHistoryItem[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+    hasNext: boolean;
+    hasPrev: boolean;
+  };
+};
+
+export type GetUserTransactionsParams = {
+  userId: number;
+  page?: number;
+  limit?: number;
+  sort?: TransactionSortOption;
+  orderId?: number;
+};
+
+export type RegisterPaymentPayload = {
+  order_id: number;
+  amount_paid: number;
+  payment_method: PaymentMethod;
+  notes?: string;
+};
+
+export type RegisterPaymentResponse = {
+  message: string;
+  order: {
+    id: number;
+    payment_state: OrderPaymentStatus;
+    total: number;
+  };
+};

--- a/src/services/user/index.ts
+++ b/src/services/user/index.ts
@@ -18,7 +18,7 @@ export const getUsersList = async ({
   page,
   limit,
   search,
-  sort = "open_first",
+  sort = "highest_debt_first",
 }: GetUsersListParams): Promise<ListUsersResponse> => {
   return api
     .get("/users/list/1/10", {
@@ -40,7 +40,7 @@ export const getUserById = async (
 
 export const getUserAccounts = async ({
   userId,
-  sort = "open_first",
+  sort = "unpaid_first",
 }: GetUserAccountsParams): Promise<UserAccountProps[]> => {
   return api
     .get(`/users/${userId}/orders`, {

--- a/src/services/user/index.ts
+++ b/src/services/user/index.ts
@@ -1,7 +1,50 @@
 import api from "@libs/axios/api";
 import { UserDates } from "@store/modules/user/types";
-import { UserPayload } from "./types";
+
+import {
+  AdminUserListItem,
+  GetUserAccountsParams,
+  GetUsersListParams,
+  ListUsersResponse,
+  UserAccountProps,
+  UserPayload,
+} from "./types";
 
 export const postUpdateUser = async (data: UserPayload): Promise<UserDates> => {
   return api.put("/users/profile", data).then((response) => response.data);
+};
+
+export const getUsersList = async ({
+  page,
+  limit,
+  search,
+  sort = "open_first",
+}: GetUsersListParams): Promise<ListUsersResponse> => {
+  return api
+    .get("/users/list/1/10", {
+      params: {
+        page,
+        limit,
+        search,
+        sort,
+      },
+    })
+    .then((response) => response.data);
+};
+
+export const getUserById = async (
+  userId: number,
+): Promise<AdminUserListItem> => {
+  return api.get(`/users/${userId}`).then((response) => response.data);
+};
+
+export const getUserAccounts = async ({
+  userId,
+  sort = "open_first",
+}: GetUserAccountsParams): Promise<UserAccountProps[]> => {
+  return api
+    .get(`/users/${userId}/orders`, {
+      params: { sort },
+    })
+    .then((response) => response.data);
 };

--- a/src/services/user/types.ts
+++ b/src/services/user/types.ts
@@ -40,11 +40,11 @@ export type GetUsersListParams = {
   page: number;
   limit: number;
   search?: string;
-  sort?: "open_first" | "name_asc";
+  sort?: "highest_debt_first" | "name_asc";
 };
 
 export type AccountSortOption =
-  | "open_first"
+  | "unpaid_first"
   | "date_desc"
   | "date_asc"
   | "balance_desc"

--- a/src/services/user/types.ts
+++ b/src/services/user/types.ts
@@ -1,3 +1,6 @@
+import { Address } from "@store/modules/user/types";
+import { OrderPaymentStatus } from "src/types/orders";
+
 export type UserPayload = {
   username: string;
   telephone?: string;
@@ -7,4 +10,72 @@ export type UserPayload = {
     number: string;
     local: string;
   };
+};
+
+export type AccountSummary = {
+  openBalance: number;
+  openAccountsCount: number;
+  overdueAccountsCount: number;
+};
+
+export type AdminUserListItem = {
+  id: number;
+  username: string;
+  email: string;
+  role: string;
+  telephone: string;
+  created_at: string;
+  addresses: Address[];
+  accountSummary: AccountSummary;
+};
+
+export type ListUsersResponse = {
+  users: AdminUserListItem[];
+  total: number;
+  page: number;
+  totalPages: number;
+};
+
+export type GetUsersListParams = {
+  page: number;
+  limit: number;
+  search?: string;
+  sort?: "open_first" | "name_asc";
+};
+
+export type AccountSortOption =
+  | "open_first"
+  | "date_desc"
+  | "date_asc"
+  | "balance_desc"
+  | "balance_asc";
+
+export type GetUserAccountsParams = {
+  userId: number;
+  sort?: AccountSortOption;
+};
+
+export type UserAccountTransaction = {
+  id: number;
+  order_id: number;
+  type: "PAYMENT" | "INTEREST" | "ADJUSTMENT";
+  amount: number;
+  old_value: number;
+  new_value: number;
+  payment_method?: string;
+  notes?: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type UserAccountProps = {
+  id: number;
+  user_id: number;
+  status: string;
+  payment_state: OrderPaymentStatus;
+  total: number;
+  updated_at: string;
+  created_at: string;
+  interest_allowed: boolean;
+  transactions?: UserAccountTransaction[];
 };


### PR DESCRIPTION
## Summary
- Adiciona tab **Clientes** na navbar admin com listagem, busca e paginação
- Implementa tela de detalhe do cliente com resumo financeiro, contas ordenáveis e histórico de transações com filtro/sort/paginação
- Integra registro de pagamento via modal conectado ao `POST /transactions`

## Test plan
- [ ] Tab Clientes aparece na navbar admin com labels (Início, Clientes, Pedidos, Perfil)
- [ ] Listagem carrega clientes com preview de saldo em aberto
- [ ] Busca por nome ou telefone funciona com debounce
- [ ] Detalhe exibe resumo, dados do cliente, contas e histórico de transações
- [ ] Ordenação e filtro de contas/transações funcionam corretamente
- [ ] Modal de pagamento registra transação e atualiza a tela
- [ ] Botão de pagamento só aparece quando há contas em aberto