### PR TITLE
feat: improve admin order creation experience

### DIFF
--- a/src/helpers/authenticated-home-route.ts
+++ b/src/helpers/authenticated-home-route.ts
@@ -1,0 +1,9 @@
+export function getAuthenticatedHomeRoute(
+  role: string
+): "adminHome" | "userHome" {
+  if (role === "ADMIN") {
+    return "adminHome";
+  }
+
+  return "userHome";
+}

--- a/src/helpers/order-item-labels.ts
+++ b/src/helpers/order-item-labels.ts
@@ -1,0 +1,59 @@
+export function getProductOrderLabel(type: string, fallbackName: string) {
+  if (type === "WATER") {
+    return {
+      title: "Água",
+      subtitle:
+        "Reposição do conteúdo. Use se o cliente já tem o vasilhame.",
+    };
+  }
+
+  if (type === "GAS") {
+    return {
+      title: "Gás",
+      subtitle: "Reposição do conteúdo. Use se o cliente já tem o botijão.",
+    };
+  }
+
+  return {
+    title: fallbackName,
+    subtitle: undefined,
+  };
+}
+
+export function getAddonSectionHeader(isExpanded: boolean) {
+  if (isExpanded) {
+    return {
+      title: "Comprar também o vasilhame",
+      subtitle: undefined,
+    };
+  }
+
+  return {
+    title: "Não tem o vasilhame?",
+    subtitle:
+      "Toque para incluir o recipiente ou botijão se o cliente ainda não tem.",
+  };
+}
+
+export function getAddonOrderLabel(type: string, fallbackName: string) {
+  if (type === "WATER_VESSEL") {
+    return {
+      title: "Vasilhame de água",
+      subtitle:
+        "Recipiente vazio. Adicione junto da água se o cliente ainda não tem o botijão.",
+    };
+  }
+
+  if (type === "GAS_VESSEL") {
+    return {
+      title: "Vasilhame de gás",
+      subtitle:
+        "Botijão vazio. Adicione junto do gás se o cliente ainda não tem o recipiente.",
+    };
+  }
+
+  return {
+    title: fallbackName,
+    subtitle: undefined,
+  };
+}

--- a/src/helpers/order-item-labels.ts
+++ b/src/helpers/order-item-labels.ts
@@ -40,7 +40,7 @@ export function getAddonOrderLabel(type: string, fallbackName: string) {
     return {
       title: "Vasilhame de água",
       subtitle:
-        "Recipiente vazio. Adicione junto da água se o cliente ainda não tem o botijão.",
+        "Recipiente vazio. Adicione junto da água se o cliente ainda não tem o vasilhame.",
     };
   }
 
@@ -48,7 +48,7 @@ export function getAddonOrderLabel(type: string, fallbackName: string) {
     return {
       title: "Vasilhame de gás",
       subtitle:
-        "Botijão vazio. Adicione junto do gás se o cliente ainda não tem o recipiente.",
+        "Botijão vazio. Adicione junto do gás se o cliente ainda não tem o botijão.",
     };
   }
 

--- a/src/routes/admin.routes.tsx
+++ b/src/routes/admin.routes.tsx
@@ -18,9 +18,9 @@ import { AdminBottomTabRoutes } from "./admin-bottom-tab.routes";
 export type AdminRoutes = {
   adminHome: undefined;
   schedule: undefined;
-  userCreateOrder: { type: ProductName };
+  userCreateOrder: { type?: ProductName };
   orderAddress: {
-    type: ProductName;
+    type?: ProductName;
     orderPayload: {
       items: Array<{
         id: number;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -8,12 +8,13 @@ import { useEffect, useState } from "react";
 import { ActivityIndicator, View } from "react-native";
 import { authSessionStorage } from "src/libs/storage/authSessionStorage";
 import { AdminRoutes } from "./admin.routes";
+import type { AdminRoutes as AdminRouteParams } from "./admin.routes";
 import { AuthRoutes } from "./auth.routes";
 import { DeliveryRoutes } from "./delivery.routes";
 import { UserRoutes } from "./user.routes";
 
 export type RootNavigatorRoutesProps = NativeStackNavigationProp<
-  AuthRoutes & UserRoutes
+  AuthRoutes & UserRoutes & AdminRouteParams
 >;
 
 export function RootRoutes() {

--- a/src/routes/user.routes.tsx
+++ b/src/routes/user.routes.tsx
@@ -17,9 +17,9 @@ import { UserBottomTabRoutes } from "./user-bottom-tab.routes";
 export type UserRoutes = {
   userHome: undefined;
   schedule: undefined;
-  userCreateOrder: { type: ProductName };
+  userCreateOrder: { type?: ProductName };
   orderAddress: {
-    type: ProductName;
+    type?: ProductName;
     orderPayload: {
       items: Array<{
         id: number;

--- a/src/screens/user/create-order/index.tsx
+++ b/src/screens/user/create-order/index.tsx
@@ -21,6 +21,7 @@ export function UserCreateOrder() {
     navigateToOrderAddress,
     total,
     navigate,
+    homeRouteName,
     incrementProduct,
     decrementProduct,
     incrementAddon,
@@ -121,7 +122,7 @@ export function UserCreateOrder() {
       <S.SafeAreaViewContainer>
         <S.ScrollViewContainer>
           <StatusBar style="light" />
-          <CustomHeader handleBack={() => navigate("userHome")} />
+          <CustomHeader handleBack={() => navigate(homeRouteName)} />
           {stockLoading ? (
             <S.AddressContainer>
               <ActivityIndicator size="large" color={theme.colors.WHITE} />

--- a/src/screens/user/create-order/index.tsx
+++ b/src/screens/user/create-order/index.tsx
@@ -4,12 +4,29 @@ import { LinearGradientBackground } from "@components/LinearGradientBackground";
 import { OrderTotal } from "@components/order-total";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { StatusBar } from "expo-status-bar";
+import { useState } from "react";
 import { ActivityIndicator, TouchableOpacity } from "react-native";
 import { formatToBRL } from "src/helpers/format-currency";
+import {
+  getAddonOrderLabel,
+  getAddonSectionHeader,
+  getProductOrderLabel,
+} from "src/helpers/order-item-labels";
 import { NumberOrZero } from "src/helpers/utils";
 import theme from "src/styles/theme";
 import * as S from "./styles";
 import { useCreateOrder } from "./use-create-order";
+
+const GAS_ORDER_IMAGE = require("../../../../assets/images/gasLogo.png");
+const WATER_ORDER_IMAGE = require("../../../../assets/images/aguaLogo.png");
+
+function getSpecificOrderImageSource(orderType?: string) {
+  if (orderType === "GAS") {
+    return GAS_ORDER_IMAGE;
+  }
+
+  return WATER_ORDER_IMAGE;
+}
 
 export function UserCreateOrder() {
   const {
@@ -30,23 +47,58 @@ export function UserCreateOrder() {
     hasAvailableStock,
     params,
   } = useCreateOrder();
+  const [isAddonSectionExpanded, setIsAddonSectionExpanded] = useState(false);
+  const addonSectionHeader = getAddonSectionHeader(isAddonSectionExpanded);
+  const addonSectionChevronIconName = isAddonSectionExpanded
+    ? "chevron-up"
+    : "chevron-down";
+
+  const toggleAddonSection = () => {
+    setIsAddonSectionExpanded((currentIsExpanded) => !currentIsExpanded);
+  };
+
+  const hasSpecificOrderType =
+    params?.type === "GAS" || params?.type === "WATER";
+  const specificOrderImageSource = getSpecificOrderImageSource(params?.type);
+
+  const renderOrderTypeImages = () => {
+    if (hasSpecificOrderType) {
+      return (
+        <S.ImageContainer>
+          <S.OrderImage source={specificOrderImageSource} />
+        </S.ImageContainer>
+      );
+    }
+
+    return (
+      <S.DualOrderImagesContainer>
+        <S.DualOrderImage source={GAS_ORDER_IMAGE} />
+        <S.DualOrderImage source={WATER_ORDER_IMAGE} />
+      </S.DualOrderImagesContainer>
+    );
+  };
 
   const renderAddonItem = (addon: {
     id: number;
     name: string;
     value: number;
+    type: string;
   }) => {
     const subtotal =
       NumberOrZero(addonQuantities[addon.id]) * NumberOrZero(addon.value);
+    const addonLabel = getAddonOrderLabel(addon.type, addon.name);
 
     return (
       <S.AddonItemContainer key={`addon-${addon.id}`}>
         <S.AddonItemTopContainer>
-          <S.OrderTitle>{addon.name}</S.OrderTitle>
+          <S.OrderTitle>{addonLabel.title}</S.OrderTitle>
+          {addonLabel.subtitle && (
+            <S.OrderItemSubtitle>{addonLabel.subtitle}</S.OrderItemSubtitle>
+          )}
         </S.AddonItemTopContainer>
 
-        <S.AddonItemBottomContainer>
-          <S.AddonQuantityContainer>
+        <S.AddItemControlsRow>
+          <S.AddItemLeftContainer>
             <TouchableOpacity onPress={() => decrementAddon(addon.id)}>
               <S.MinusPlusButton>
                 <MaterialCommunityIcons
@@ -65,9 +117,9 @@ export function UserCreateOrder() {
                 <MaterialCommunityIcons name="plus" size={25} color="#ffffff" />
               </S.MinusPlusButton>
             </TouchableOpacity>
-          </S.AddonQuantityContainer>
-          <S.ValueText>{formatToBRL(subtotal)}</S.ValueText>
-        </S.AddonItemBottomContainer>
+          </S.AddItemLeftContainer>
+          <S.OrderPrice>{formatToBRL(subtotal)}</S.OrderPrice>
+        </S.AddItemControlsRow>
       </S.AddonItemContainer>
     );
   };
@@ -77,42 +129,56 @@ export function UserCreateOrder() {
     name: string;
     value: number;
     quantity: number;
+    type: string;
   }) => {
     const qty = NumberOrZero(productQuantities[item.id]);
     const unit = NumberOrZero(item.value);
     const subtotal = qty * unit;
     const isProductOutOfStock = item.quantity <= 0;
     const hasReachedStockLimit = qty >= item.quantity;
+    const productLabel = getProductOrderLabel(item.type, item.name);
 
     return (
       <S.AddItemContainer key={`product-${item.id}`}>
-        <S.AddItemLeftContainer>
-          <TouchableOpacity
-            onPress={() => decrementProduct(item.id)}
-            disabled={isProductOutOfStock}
-          >
-            <S.MinusPlusButton>
-              <MaterialCommunityIcons name="minus" size={25} color="#ffffff" />
-            </S.MinusPlusButton>
-          </TouchableOpacity>
-          <S.SecondOrderAddItemNumber>
-            {productQuantities[item.id] || 0}
-          </S.SecondOrderAddItemNumber>
+        <S.ProductInfoContainer>
+          <S.OrderTitle>{productLabel.title}</S.OrderTitle>
+          {productLabel.subtitle && (
+            <S.OrderItemSubtitle>{productLabel.subtitle}</S.OrderItemSubtitle>
+          )}
+        </S.ProductInfoContainer>
+        <S.AddItemControlsRow>
+          <S.AddItemLeftContainer>
+            <TouchableOpacity
+              onPress={() => decrementProduct(item.id)}
+              disabled={isProductOutOfStock}
+            >
+              <S.MinusPlusButton>
+                <MaterialCommunityIcons
+                  name="minus"
+                  size={25}
+                  color="#ffffff"
+                />
+              </S.MinusPlusButton>
+            </TouchableOpacity>
+            <S.SecondOrderAddItemNumber>
+              {productQuantities[item.id] || 0}
+            </S.SecondOrderAddItemNumber>
 
-          <TouchableOpacity
-            onPress={() => incrementProduct(item.id)}
-            disabled={isProductOutOfStock || hasReachedStockLimit}
-          >
-            <S.MinusPlusButton>
-              <MaterialCommunityIcons name="plus" size={25} color="#ffffff" />
-            </S.MinusPlusButton>
-          </TouchableOpacity>
-        </S.AddItemLeftContainer>
-
-        <S.AddItemRightContainer>
-          <S.OrderTitle>{item.name}</S.OrderTitle>
-          <S.OrderTitle>{formatToBRL(subtotal)}</S.OrderTitle>
-        </S.AddItemRightContainer>
+            <TouchableOpacity
+              onPress={() => incrementProduct(item.id)}
+              disabled={isProductOutOfStock || hasReachedStockLimit}
+            >
+              <S.MinusPlusButton>
+                <MaterialCommunityIcons
+                  name="plus"
+                  size={25}
+                  color="#ffffff"
+                />
+              </S.MinusPlusButton>
+            </TouchableOpacity>
+          </S.AddItemLeftContainer>
+          <S.OrderPrice>{formatToBRL(subtotal)}</S.OrderPrice>
+        </S.AddItemControlsRow>
       </S.AddItemContainer>
     );
   };
@@ -130,17 +196,10 @@ export function UserCreateOrder() {
           ) : (
             <>
               <S.AddressContainer>
-                <S.ImageContainer>
-                  <S.OrderImage
-                    source={
-                      params.type === "GAS"
-                        ? require("../../../../assets/images/gasLogo.png")
-                        : require("../../../../assets/images/aguaLogo.png")
-                    }
-                  />
-                </S.ImageContainer>
+                {renderOrderTypeImages()}
 
                 <S.OrderContainer>
+                  <S.OrderSectionTitle>Reposição</S.OrderSectionTitle>
                   {hasAvailableStock ? (
                     products.map(renderProductItem)
                   ) : (
@@ -150,10 +209,33 @@ export function UserCreateOrder() {
                   )}
                 </S.OrderContainer>
 
-                {hasAvailableStock && (
-                  <S.AddonBoxContainer>
-                    {addons.map(renderAddonItem)}
-                  </S.AddonBoxContainer>
+                {hasAvailableStock && addons.length > 0 && (
+                  <S.AddonSectionContainer>
+                    <S.AddonSectionHeader
+                      onPress={toggleAddonSection}
+                      accessibilityRole="button"
+                      accessibilityState={{
+                        expanded: isAddonSectionExpanded,
+                      }}
+                    >
+                      <S.AddonSectionHeaderTextContainer>
+                        <S.AddonSectionHeaderTitle>
+                          {addonSectionHeader.title}
+                        </S.AddonSectionHeaderTitle>
+                        {addonSectionHeader.subtitle && (
+                          <S.OrderItemSubtitle>
+                            {addonSectionHeader.subtitle}
+                          </S.OrderItemSubtitle>
+                        )}
+                      </S.AddonSectionHeaderTextContainer>
+                      <MaterialCommunityIcons
+                        name={addonSectionChevronIconName}
+                        size={24}
+                        color={theme.colors.ORANGE_300}
+                      />
+                    </S.AddonSectionHeader>
+                    {isAddonSectionExpanded && addons.map(renderAddonItem)}
+                  </S.AddonSectionContainer>
                 )}
               </S.AddressContainer>
 

--- a/src/screens/user/create-order/styles.ts
+++ b/src/screens/user/create-order/styles.ts
@@ -26,11 +26,24 @@ export const ImageContainer = styled.View`
   height: ${theme.size.m13};
 `;
 
-export const AddItemContainer = styled.View`
+export const DualOrderImagesContainer = styled.View`
   flex-direction: row;
   align-items: center;
-  justify-content: space-between;
-  padding: ${theme.size.m3};
+  justify-content: center;
+  margin-bottom: -40px;
+  z-index: ${theme.font.size.m1};
+  gap: ${theme.size.m2};
+`;
+
+export const DualOrderImage = styled(OrderImage)`
+  width: ${theme.size.m12};
+  height: ${theme.size.m12};
+`;
+
+export const AddItemContainer = styled.View`
+  width: 100%;
+  padding: ${theme.size.m3} 0;
+  gap: ${theme.size.m2};
 `;
 
 export const MinusPlusButton = styled.View`
@@ -96,6 +109,32 @@ export const OrderTitle = styled.Text`
   font-weight: ${theme.font.weight.bold};
 `;
 
+export const OrderSectionTitle = styled.Text`
+  color: ${theme.colors.ORANGE_300};
+  font-size: ${theme.font.size.m4};
+  font-weight: ${theme.font.weight.bold};
+  align-self: flex-start;
+  margin-bottom: ${theme.size.m2};
+`;
+
+export const OrderItemSubtitle = styled.Text`
+  color: ${theme.colors.GRAY_300};
+  font-size: ${theme.font.size.m3};
+  font-weight: ${theme.font.weight.medium};
+  margin-top: ${theme.size.m1};
+  line-height: 20px;
+`;
+
+export const ProductInfoContainer = styled.View`
+  width: 100%;
+`;
+
+export const OrderPrice = styled.Text`
+  color: ${theme.colors.GRAY_700};
+  font-size: ${theme.font.size.m5};
+  font-weight: ${theme.font.weight.bold};
+`;
+
 export const UnavailableStockMessage = styled(OrderTitle)`
   text-align: center;
   padding: ${theme.size.m8} ${theme.size.m4};
@@ -105,16 +144,13 @@ export const ValueText = styled.Text`
   color: ${theme.colors.GRAY_700};
   font-size: ${theme.font.size.m5};
   font-weight: ${theme.font.weight.bold};
-  margin-left: ${theme.size.m2};
-  flex: 1;
 `;
 
-export const AddItemRightContainer = styled.View`
+export const AddItemControlsRow = styled.View`
   flex-direction: row;
+  align-items: center;
   justify-content: space-between;
-  gap: ${theme.size.m9};
-  margin-left: ${theme.size.m4};
-  flex: 1;
+  width: 100%;
 `;
 
 export const AddItemLeftContainer = styled.View`
@@ -127,7 +163,8 @@ export const AddItemLeftContainer = styled.View`
 export const AddonItemBottomContainer = styled.View`
   flex-direction: row;
   align-items: center;
-  justify-content: space-evenly;
+  justify-content: space-between;
+  width: 100%;
 `;
 
 export const AddonQuantityContainer = styled.View`
@@ -139,22 +176,29 @@ export const AddonQuantityContainer = styled.View`
 `;
 
 export const AddonItemTopContainer = styled.View`
-  flex-direction: row;
-  align-items: center;
+  flex-direction: column;
+  align-items: flex-start;
   justify-content: center;
-  gap: ${theme.size.m2};
+  width: 100%;
+  gap: ${theme.size.m1};
 `;
 
 export const AddonItemContainer = styled.View`
   flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
-  padding: ${theme.size.m4};
-  padding-horizontal: ${theme.size.m9};
+  padding: ${theme.size.m3} 0;
   width: 100%;
-  background-color: ${theme.colors.WHITE};
-  border-radius: ${theme.size.m4};
   gap: ${theme.size.m3};
+`;
+
+export const AddonSectionContainer = styled.View`
+  background-color: ${theme.colors.WHITE};
+  padding: ${theme.font.size.m7};
+  border-radius: ${theme.size.m6};
+  align-items: flex-start;
+  width: 100%;
+  gap: ${theme.size.m2};
 
   elevation: 5;
   shadow-color: #000;
@@ -163,11 +207,21 @@ export const AddonItemContainer = styled.View`
   shadow-offset: 3px;
 `;
 
-export const AddonBoxContainer = styled.View`
-  width: 100%;
+export const AddonSectionHeader = styled.TouchableOpacity`
+  flex-direction: row;
   align-items: center;
   justify-content: space-between;
-  gap: ${theme.size.m3};
+  width: 100%;
+  gap: ${theme.size.m2};
+`;
+
+export const AddonSectionHeaderTextContainer = styled.View`
+  flex: 1;
+`;
+
+export const AddonSectionHeaderTitle = styled(OrderSectionTitle)`
+  margin-bottom: 0;
+  align-self: auto;
 `;
 
 export const OrderTotalContainer = styled.View`

--- a/src/screens/user/create-order/use-create-order.ts
+++ b/src/screens/user/create-order/use-create-order.ts
@@ -155,7 +155,7 @@ export const useCreateOrder = () => {
     const orderPayload = buildOrderPayload();
 
     navigate("orderAddress", {
-      type: params.type,
+      type: params?.type,
       orderPayload,
       totalValue: total,
     });

--- a/src/screens/user/create-order/use-create-order.ts
+++ b/src/screens/user/create-order/use-create-order.ts
@@ -1,8 +1,10 @@
+import { useAppSelector } from "@hooks/useAppSelector";
 import { RouteProp, useNavigation, useRoute } from "@react-navigation/native";
 import { RootNavigatorRoutesProps } from "@routes/index";
 import { UserRoutes } from "@routes/user.routes";
 import { errorHandler } from "@utils/error-handler";
 import React, { useEffect, useMemo, useState } from "react";
+import { getAuthenticatedHomeRoute } from "src/helpers/authenticated-home-route";
 import { formatToBRL } from "src/helpers/format-currency";
 import { getAddons } from "src/services/addon";
 import { getStock } from "src/services/order";
@@ -10,6 +12,10 @@ import { getStock } from "src/services/order";
 export const useCreateOrder = () => {
   const { params } = useRoute<RouteProp<UserRoutes, "userCreateOrder">>();
   const { navigate } = useNavigation<RootNavigatorRoutesProps>();
+  const {
+    user: { role },
+  } = useAppSelector((state) => state.user);
+  const homeRouteName = getAuthenticatedHomeRoute(role);
 
   const [stockLoading, setIsStockLoading] = useState(false);
   const [products, setProducts] = useState<
@@ -190,6 +196,7 @@ export const useCreateOrder = () => {
     decrementAddon,
 
     navigate,
+    homeRouteName,
     params,
   };
 };

--- a/src/screens/user/order-address/index.tsx
+++ b/src/screens/user/order-address/index.tsx
@@ -2,8 +2,15 @@ import { Button } from "@components/button";
 import { CustomHeader } from "@components/custom-header";
 import { LinearGradientBackground } from "@components/LinearGradientBackground";
 import { OrderTotal } from "@components/order-total";
-import { MaterialIcons } from "@expo/vector-icons";
+import { MaterialCommunityIcons, MaterialIcons } from "@expo/vector-icons";
 import { StatusBar } from "expo-status-bar";
+import { Controller } from "react-hook-form";
+import { KeyboardAvoidingView, Platform } from "react-native";
+import {
+  DEFAULT_CITY,
+  DEFAULT_ENGENHO,
+  ENGENHO_OPTIONS,
+} from "src/constants/localOptions";
 import theme from "src/styles/theme";
 import * as S from "./styles";
 import { useOrderAddress } from "./use-order-address";
@@ -13,82 +20,243 @@ export function OrderAddress() {
     params,
     address,
     isLoading,
+    isAdmin,
     handleCreateOrder,
+    handleCreateAdminOrder,
+    handleSubmit,
+    control,
+    errors,
+    setValue,
+    mainLocal,
+    setMainLocal,
+    selectedEngenho,
+    setSelectedEngenho,
     navigate,
     orderSummary,
     handChangeAddress,
   } = useOrderAddress();
 
+  let confirmOrderAction = handleCreateOrder;
+  let keyboardAvoidingBehavior: "padding" | undefined;
+
+  if (isAdmin) {
+    confirmOrderAction = handleSubmit(handleCreateAdminOrder);
+  }
+
+  if (Platform.OS === "ios") {
+    keyboardAvoidingBehavior = "padding";
+  }
+
   return (
     <LinearGradientBackground>
-      <S.SafeAreaViewContainer>
-        <StatusBar style="light" />
-        <CustomHeader
-          handleBack={() => navigate("userCreateOrder", { type: params.type })}
-        />
-
-        <S.AddressContainer>
-          <S.AddressSubContainer>
-            <S.Title>Endereço de entrega</S.Title>
-            <S.AddressTextContainer>
-              <MaterialIcons name="location-pin" size={20} color="#7e7e7e" />
-              <S.SubTitle>
-                {address?.street} {address?.number}
-              </S.SubTitle>
-            </S.AddressTextContainer>
-
-            <S.Title>Referência</S.Title>
-            <S.SubTitle>{address?.reference}</S.SubTitle>
-
-            <S.AlterAddressButton onPress={handChangeAddress}>
-              <S.AlterLocationButtonText>
-                Alterar endereço de entrega
-              </S.AlterLocationButtonText>
-            </S.AlterAddressButton>
-          </S.AddressSubContainer>
-        </S.AddressContainer>
-
-        <S.OrderSummaryContainer>
-          <S.Title>Resumo do Pedido</S.Title>
-          <S.OrderItem>
-            {orderSummary.items.map((item) => (
-              <S.OrderItemRow key={`item-${item.id}`}>
-                <S.OrderItemText>
-                  {item.quantity} {item.name}
-                </S.OrderItemText>
-                <S.OrderItemValue>{item.subtotal}</S.OrderItemValue>
-              </S.OrderItemRow>
-            ))}
-            {orderSummary.addons.map((addon) => (
-              <S.OrderItemRow key={`addon-${addon.id}`}>
-                <S.OrderItemText>
-                  {addon.quantity} {addon.name}
-                </S.OrderItemText>
-                <S.OrderItemValue>{addon.subtotal}</S.OrderItemValue>
-              </S.OrderItemRow>
-            ))}
-          </S.OrderItem>
-        </S.OrderSummaryContainer>
-
-        <S.OrderTotalContainer>
-          <OrderTotal
-            totalItems={orderSummary.totalItems}
-            totalValue={params.totalValue}
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior={keyboardAvoidingBehavior}
+      >
+        <S.SafeAreaViewContainer>
+          <StatusBar style="light" />
+          <CustomHeader
+            handleBack={() =>
+              navigate("userCreateOrder", { type: params.type })
+            }
           />
-        </S.OrderTotalContainer>
 
-        <S.ButtonContainer>
-          <Button
-            onPress={handleCreateOrder}
-            isLoading={isLoading}
-            color={theme.colors.ORANGE_200}
-          >
-            <S.ConfirmOrderButtonText>
-              Confirmar pedido
-            </S.ConfirmOrderButtonText>
-          </Button>
-        </S.ButtonContainer>
-      </S.SafeAreaViewContainer>
+          <S.ScrollViewContainer>
+            <S.AddressContainer>
+              <S.AddressSubContainer>
+                <S.Title>Endereço de entrega</S.Title>
+                {isAdmin ? (
+                  <>
+                    <Controller
+                      control={control}
+                      name="local"
+                      render={({ field: { onChange } }) => (
+                        <S.InputArea>
+                          <S.SelectInput
+                            selectedValue={mainLocal}
+                            onValueChange={(value: string) => {
+                              onChange(value);
+                              setMainLocal(value);
+                              if (value === DEFAULT_CITY) {
+                                setValue("local", DEFAULT_CITY);
+                              }
+                            }}
+                          >
+                            <S.SelectInput.Item
+                              label={DEFAULT_CITY}
+                              value={DEFAULT_CITY}
+                            />
+                            <S.SelectInput.Item
+                              label={DEFAULT_ENGENHO}
+                              value={DEFAULT_ENGENHO}
+                            />
+                          </S.SelectInput>
+                        </S.InputArea>
+                      )}
+                    />
+
+                    {mainLocal === DEFAULT_ENGENHO && (
+                      <S.InputArea>
+                        <S.SelectInput
+                          selectedValue={selectedEngenho}
+                          onValueChange={(value: string) => {
+                            setSelectedEngenho(value);
+                            setValue("local", value);
+                          }}
+                        >
+                          {ENGENHO_OPTIONS.map((option) => (
+                            <S.SelectInput.Item
+                              key={option}
+                              label={option}
+                              value={option}
+                            />
+                          ))}
+                        </S.SelectInput>
+                      </S.InputArea>
+                    )}
+
+                    {mainLocal !== DEFAULT_ENGENHO && (
+                      <S.StreetNumberInputContainer>
+                        <Controller
+                          control={control}
+                          name="street"
+                          render={({ field: { onChange, value } }) => (
+                            <S.InputArea>
+                              <MaterialCommunityIcons
+                                name="map-marker"
+                                size={20}
+                                color="#7e7e7e"
+                              />
+                              <S.Input
+                                value={value}
+                                onChangeText={onChange}
+                                placeholder="Rua"
+                              />
+                            </S.InputArea>
+                          )}
+                        />
+                        <Controller
+                          control={control}
+                          name="number"
+                          render={({ field: { onChange, value } }) => (
+                            <S.InputArea>
+                              <MaterialCommunityIcons
+                                name="map-marker"
+                                size={20}
+                                color="#7e7e7e"
+                              />
+                              <S.Input
+                                value={value}
+                                onChangeText={onChange}
+                                placeholder="Número"
+                              />
+                            </S.InputArea>
+                          )}
+                        />
+                      </S.StreetNumberInputContainer>
+                    )}
+
+                    <Controller
+                      control={control}
+                      name="reference"
+                      render={({ field: { onChange, value } }) => (
+                        <S.InputArea>
+                          <MaterialCommunityIcons
+                            name="map-marker"
+                            size={20}
+                            color="#7e7e7e"
+                          />
+                          <S.Input
+                            placeholder="Referência"
+                            onChangeText={onChange}
+                            value={value}
+                          />
+                        </S.InputArea>
+                      )}
+                    />
+
+                    {errors.local && (
+                      <S.LabelError>{errors.local.message}</S.LabelError>
+                    )}
+                    {errors.street && (
+                      <S.LabelError>{errors.street.message}</S.LabelError>
+                    )}
+                    {errors.number && (
+                      <S.LabelError>{errors.number.message}</S.LabelError>
+                    )}
+                    {errors.reference && (
+                      <S.LabelError>{errors.reference.message}</S.LabelError>
+                    )}
+                  </>
+                ) : (
+                  <>
+                    <S.AddressTextContainer>
+                      <MaterialIcons
+                        name="location-pin"
+                        size={20}
+                        color="#7e7e7e"
+                      />
+                      <S.SubTitle>
+                        {address?.street} {address?.number}
+                      </S.SubTitle>
+                    </S.AddressTextContainer>
+
+                    <S.Title>Referência</S.Title>
+                    <S.SubTitle>{address?.reference}</S.SubTitle>
+
+                    <S.AlterAddressButton onPress={handChangeAddress}>
+                      <S.AlterLocationButtonText>
+                        Alterar endereço de entrega
+                      </S.AlterLocationButtonText>
+                    </S.AlterAddressButton>
+                  </>
+                )}
+              </S.AddressSubContainer>
+            </S.AddressContainer>
+
+            <S.OrderSummaryContainer>
+              <S.Title>Resumo do Pedido</S.Title>
+              <S.OrderItem>
+                {orderSummary.items.map((item) => (
+                  <S.OrderItemRow key={`item-${item.id}`}>
+                    <S.OrderItemText>
+                      {item.quantity} {item.name}
+                    </S.OrderItemText>
+                    <S.OrderItemValue>{item.subtotal}</S.OrderItemValue>
+                  </S.OrderItemRow>
+                ))}
+                {orderSummary.addons.map((addon) => (
+                  <S.OrderItemRow key={`addon-${addon.id}`}>
+                    <S.OrderItemText>
+                      {addon.quantity} {addon.name}
+                    </S.OrderItemText>
+                    <S.OrderItemValue>{addon.subtotal}</S.OrderItemValue>
+                  </S.OrderItemRow>
+                ))}
+              </S.OrderItem>
+            </S.OrderSummaryContainer>
+
+            <S.OrderTotalContainer>
+              <OrderTotal
+                totalItems={orderSummary.totalItems}
+                totalValue={params.totalValue}
+              />
+            </S.OrderTotalContainer>
+
+            <S.ButtonContainer>
+              <Button
+                onPress={confirmOrderAction}
+                isLoading={isLoading}
+                color={theme.colors.ORANGE_200}
+              >
+                <S.ConfirmOrderButtonText>
+                  Confirmar pedido
+                </S.ConfirmOrderButtonText>
+              </Button>
+            </S.ButtonContainer>
+          </S.ScrollViewContainer>
+        </S.SafeAreaViewContainer>
+      </KeyboardAvoidingView>
     </LinearGradientBackground>
   );
 }

--- a/src/screens/user/order-address/index.tsx
+++ b/src/screens/user/order-address/index.tsx
@@ -57,7 +57,7 @@ export function OrderAddress() {
           <StatusBar style="light" />
           <CustomHeader
             handleBack={() =>
-              navigate("userCreateOrder", { type: params.type })
+              navigate("userCreateOrder", { type: params?.type })
             }
           />
 

--- a/src/screens/user/order-address/index.tsx
+++ b/src/screens/user/order-address/index.tsx
@@ -26,11 +26,10 @@ export function OrderAddress() {
     handleSubmit,
     control,
     errors,
-    setValue,
     mainLocal,
-    setMainLocal,
     selectedEngenho,
-    setSelectedEngenho,
+    handleMainLocalChange,
+    handleEngenhoChange,
     navigate,
     orderSummary,
     handChangeAddress,
@@ -67,93 +66,95 @@ export function OrderAddress() {
                 <S.Title>Endereço de entrega</S.Title>
                 {isAdmin ? (
                   <>
-                    <Controller
-                      control={control}
-                      name="local"
-                      render={({ field: { onChange } }) => (
-                        <S.InputArea>
-                          <S.SelectInput
-                            selectedValue={mainLocal}
-                            onValueChange={(value: string) => {
-                              onChange(value);
-                              setMainLocal(value);
-                              if (value === DEFAULT_CITY) {
-                                setValue("local", DEFAULT_CITY);
-                              }
-                            }}
-                          >
-                            <S.SelectInput.Item
-                              label={DEFAULT_CITY}
-                              value={DEFAULT_CITY}
-                            />
-                            <S.SelectInput.Item
-                              label={DEFAULT_ENGENHO}
-                              value={DEFAULT_ENGENHO}
-                            />
-                          </S.SelectInput>
-                        </S.InputArea>
-                      )}
-                    />
+                    <S.InputArea>
+                      <S.SelectInput
+                        selectedValue={mainLocal}
+                        onValueChange={handleMainLocalChange}
+                      >
+                        <S.SelectInput.Item
+                          label={DEFAULT_CITY}
+                          value={DEFAULT_CITY}
+                        />
+                        <S.SelectInput.Item
+                          label={DEFAULT_ENGENHO}
+                          value={DEFAULT_ENGENHO}
+                        />
+                      </S.SelectInput>
+                    </S.InputArea>
 
                     {mainLocal === DEFAULT_ENGENHO && (
-                      <S.InputArea>
-                        <S.SelectInput
-                          selectedValue={selectedEngenho}
-                          onValueChange={(value: string) => {
-                            setSelectedEngenho(value);
-                            setValue("local", value);
-                          }}
-                        >
-                          {ENGENHO_OPTIONS.map((option) => (
+                      <>
+                        <S.InputArea>
+                          <S.SelectInput
+                            selectedValue={selectedEngenho}
+                            onValueChange={handleEngenhoChange}
+                          >
                             <S.SelectInput.Item
-                              key={option}
-                              label={option}
-                              value={option}
+                              label="Selecione o engenho"
+                              value=""
                             />
-                          ))}
-                        </S.SelectInput>
-                      </S.InputArea>
+                            {ENGENHO_OPTIONS.map((option) => (
+                              <S.SelectInput.Item
+                                key={option}
+                                label={option}
+                                value={option}
+                              />
+                            ))}
+                          </S.SelectInput>
+                        </S.InputArea>
+                        {errors.local && (
+                          <S.LabelError>{errors.local.message}</S.LabelError>
+                        )}
+                      </>
                     )}
 
                     {mainLocal !== DEFAULT_ENGENHO && (
-                      <S.StreetNumberInputContainer>
-                        <Controller
-                          control={control}
-                          name="street"
-                          render={({ field: { onChange, value } }) => (
-                            <S.InputArea>
-                              <MaterialCommunityIcons
-                                name="map-marker"
-                                size={20}
-                                color="#7e7e7e"
-                              />
-                              <S.Input
-                                value={value}
-                                onChangeText={onChange}
-                                placeholder="Rua"
-                              />
-                            </S.InputArea>
-                          )}
-                        />
-                        <Controller
-                          control={control}
-                          name="number"
-                          render={({ field: { onChange, value } }) => (
-                            <S.InputArea>
-                              <MaterialCommunityIcons
-                                name="map-marker"
-                                size={20}
-                                color="#7e7e7e"
-                              />
-                              <S.Input
-                                value={value}
-                                onChangeText={onChange}
-                                placeholder="Número"
-                              />
-                            </S.InputArea>
-                          )}
-                        />
-                      </S.StreetNumberInputContainer>
+                      <>
+                        <S.StreetNumberInputContainer>
+                          <Controller
+                            control={control}
+                            name="street"
+                            render={({ field: { onChange, value } }) => (
+                              <S.InputArea>
+                                <MaterialCommunityIcons
+                                  name="map-marker"
+                                  size={20}
+                                  color="#7e7e7e"
+                                />
+                                <S.Input
+                                  value={value}
+                                  onChangeText={onChange}
+                                  placeholder="Rua"
+                                />
+                              </S.InputArea>
+                            )}
+                          />
+                          <Controller
+                            control={control}
+                            name="number"
+                            render={({ field: { onChange, value } }) => (
+                              <S.InputArea>
+                                <MaterialCommunityIcons
+                                  name="map-marker"
+                                  size={20}
+                                  color="#7e7e7e"
+                                />
+                                <S.Input
+                                  value={value}
+                                  onChangeText={onChange}
+                                  placeholder="Número"
+                                />
+                              </S.InputArea>
+                            )}
+                          />
+                        </S.StreetNumberInputContainer>
+                        {errors.street && (
+                          <S.LabelError>{errors.street.message}</S.LabelError>
+                        )}
+                        {errors.number && (
+                          <S.LabelError>{errors.number.message}</S.LabelError>
+                        )}
+                      </>
                     )}
 
                     <Controller
@@ -174,16 +175,6 @@ export function OrderAddress() {
                         </S.InputArea>
                       )}
                     />
-
-                    {errors.local && (
-                      <S.LabelError>{errors.local.message}</S.LabelError>
-                    )}
-                    {errors.street && (
-                      <S.LabelError>{errors.street.message}</S.LabelError>
-                    )}
-                    {errors.number && (
-                      <S.LabelError>{errors.number.message}</S.LabelError>
-                    )}
                     {errors.reference && (
                       <S.LabelError>{errors.reference.message}</S.LabelError>
                     )}

--- a/src/screens/user/order-address/styles.ts
+++ b/src/screens/user/order-address/styles.ts
@@ -1,10 +1,22 @@
 import styled from "styled-components/native";
+import { Picker } from "@react-native-picker/picker";
 import theme from "../../../styles/theme";
 
 export const SafeAreaViewContainer = styled.View`
   flex: 1;
   padding: ${theme.size.m7};
   justify-content: flex-start;
+`;
+
+export const ScrollViewContainer = styled.ScrollView.attrs({
+  contentContainerStyle: {
+    flexGrow: 1,
+    paddingBottom: 24,
+  },
+  showsVerticalScrollIndicator: false,
+  keyboardShouldPersistTaps: "handled",
+})`
+  flex: 1;
 `;
 
 export const AddressContainer = styled.View`
@@ -105,7 +117,6 @@ export const OrderTotalContainer = styled.View`
 `;
 
 export const ButtonContainer = styled.View`
-  flex: 1;
   justify-content: flex-end;
   align-items: center;
   padding-bottom: ${theme.size.m6};
@@ -115,4 +126,41 @@ export const ConfirmOrderButtonText = styled.Text`
   color: ${theme.colors.WHITE};
   font-size: ${theme.font.size.m4};
   font-weight: ${theme.font.weight.bold};
+`;
+
+export const InputArea = styled.View`
+  padding: ${theme.size.base};
+  width: 100%;
+  align-items: center;
+  border-radius: ${theme.size.m4};
+  border: ${theme.colors.GRAY_200};
+  background-color: ${theme.colors.GRAY_100};
+  flex-direction: row;
+  flex: 1;
+  max-height: 55px;
+`;
+
+export const Input = styled.TextInput`
+  flex: 1;
+  font-size: ${theme.size.m4};
+  margin-left: ${theme.size.m2};
+`;
+
+export const SelectInput = styled(Picker)`
+  color: ${theme.colors.GRAY_500};
+  justify-content: center;
+  text-align: start;
+  font-size: ${theme.font.size.m6};
+  border-radius: ${theme.size.m1};
+  width: 100%;
+`;
+
+export const StreetNumberInputContainer = styled.View`
+  flex-direction: row;
+  gap: ${theme.size.m3};
+`;
+
+export const LabelError = styled.Text`
+  align-self: flex-start;
+  color: #ff375b;
 `;

--- a/src/screens/user/order-address/use-order-address.ts
+++ b/src/screens/user/order-address/use-order-address.ts
@@ -14,19 +14,61 @@ import { postOrder } from "src/services/order";
 import { OrderDeliveryAddress, OrderPayload } from "src/services/order/types";
 import * as yup from "yup";
 
+function isJaqueiraLocal(local?: string) {
+  return local === DEFAULT_CITY;
+}
+
 const deliveryAddressSchema = yup.object({
-  street: yup.string(),
-  number: yup.string(),
-  reference: yup.string().required("Informe uma referência do endereço"),
-  local: yup.string().required("Informe a localidade"),
+  local: yup
+    .string()
+    .trim()
+    .required("Selecione o engenho")
+    .test(
+      "is-specific-locality",
+      "Selecione o engenho",
+      (localValue) => Boolean(localValue) && localValue !== DEFAULT_ENGENHO
+    ),
+  street: yup.string().when("local", {
+    is: DEFAULT_CITY,
+    then: (schema) =>
+      schema.trim().required("Informe a rua").min(1, "Informe a rua"),
+    otherwise: (schema) => schema.strip(),
+  }),
+  number: yup.string().when("local", {
+    is: DEFAULT_CITY,
+    then: (schema) =>
+      schema.trim().required("Informe o número").min(1, "Informe o número"),
+    otherwise: (schema) => schema.strip(),
+  }),
+  reference: yup
+    .string()
+    .trim()
+    .required("Informe uma referência do endereço")
+    .min(1, "Informe uma referência do endereço"),
 });
+
+function buildAdminCustomAddress(deliveryAddress: OrderDeliveryAddress) {
+  if (isJaqueiraLocal(deliveryAddress.local)) {
+    return {
+      local: deliveryAddress.local,
+      street: deliveryAddress.street,
+      number: deliveryAddress.number,
+      reference: deliveryAddress.reference,
+    };
+  }
+
+  return {
+    local: deliveryAddress.local,
+    reference: deliveryAddress.reference,
+  };
+}
 
 export const useOrderAddress = () => {
   const { params } = useRoute<RouteProp<UserRoutes, "orderAddress">>();
   const { navigate } = useNavigation<RootNavigatorRoutesProps>();
   const [isLoading, setIsLoading] = useState(false);
   const [mainLocal, setMainLocal] = useState(DEFAULT_CITY);
-  const [selectedEngenho, setSelectedEngenho] = useState(DEFAULT_ENGENHO);
+  const [selectedEngenho, setSelectedEngenho] = useState("");
 
   const {
     user: { addresses, role },
@@ -40,6 +82,7 @@ export const useOrderAddress = () => {
     handleSubmit,
     formState: { errors },
     setValue,
+    clearErrors,
   } = useForm<OrderDeliveryAddress>({
     resolver: yupResolver(deliveryAddressSchema),
     defaultValues: {
@@ -49,6 +92,26 @@ export const useOrderAddress = () => {
       reference: "",
     },
   });
+
+  const handleMainLocalChange = (selectedMainLocal: string) => {
+    setMainLocal(selectedMainLocal);
+    setSelectedEngenho("");
+    setValue("street", "");
+    setValue("number", "");
+    clearErrors(["street", "number", "local"]);
+
+    if (selectedMainLocal === DEFAULT_CITY) {
+      setValue("local", DEFAULT_CITY);
+      return;
+    }
+
+    setValue("local", "");
+  };
+
+  const handleEngenhoChange = (selectedEngenhoName: string) => {
+    setSelectedEngenho(selectedEngenhoName);
+    setValue("local", selectedEngenhoName, { shouldValidate: true });
+  };
 
   const defaultAddress = addresses.find(
     (address) => address.isDefault === true,
@@ -120,7 +183,8 @@ export const useOrderAddress = () => {
   }
 
   async function handleCreateAdminOrder(deliveryAddress: OrderDeliveryAddress) {
-    await submitOrder(deliveryAddress);
+    const customAddress = buildAdminCustomAddress(deliveryAddress);
+    await submitOrder(customAddress);
   }
 
   const handChangeAddress = () => {
@@ -140,11 +204,10 @@ export const useOrderAddress = () => {
     handleSubmit,
     control,
     errors,
-    setValue,
     mainLocal,
-    setMainLocal,
     selectedEngenho,
-    setSelectedEngenho,
+    handleMainLocalChange,
+    handleEngenhoChange,
     navigate,
     orderSummary,
     handChangeAddress,

--- a/src/screens/user/order-address/use-order-address.ts
+++ b/src/screens/user/order-address/use-order-address.ts
@@ -1,27 +1,58 @@
+import { yupResolver } from "@hookform/resolvers/yup";
 import { useAppSelector } from "@hooks/useAppSelector";
 import { RouteProp, useNavigation, useRoute } from "@react-navigation/native";
 import { RootNavigatorRoutesProps } from "@routes/index";
 import { UserRoutes } from "@routes/user.routes";
 import { isAxiosError } from "axios";
 import { useMemo, useState } from "react";
+import { useForm } from "react-hook-form";
 import Toast from "react-native-toast-message";
+import { DEFAULT_CITY, DEFAULT_ENGENHO } from "src/constants/localOptions";
+import { getAuthenticatedHomeRoute } from "src/helpers/authenticated-home-route";
 import { formatToBRL } from "src/helpers/format-currency";
 import { postOrder } from "src/services/order";
+import { OrderDeliveryAddress, OrderPayload } from "src/services/order/types";
+import * as yup from "yup";
+
+const deliveryAddressSchema = yup.object({
+  street: yup.string(),
+  number: yup.string(),
+  reference: yup.string().required("Informe uma referência do endereço"),
+  local: yup.string().required("Informe a localidade"),
+});
 
 export const useOrderAddress = () => {
   const { params } = useRoute<RouteProp<UserRoutes, "orderAddress">>();
   const { navigate } = useNavigation<RootNavigatorRoutesProps>();
   const [isLoading, setIsLoading] = useState(false);
+  const [mainLocal, setMainLocal] = useState(DEFAULT_CITY);
+  const [selectedEngenho, setSelectedEngenho] = useState(DEFAULT_ENGENHO);
 
   const {
-    user: { addresses },
+    user: { addresses, role },
   } = useAppSelector((state) => state.user);
 
-  const defaultAddress = addresses.find(
-    (address) => address.isDefault === true
-  );
+  const isAdmin = role === "ADMIN";
+  const homeRouteName = getAuthenticatedHomeRoute(role);
 
-  console.log({ addresses });
+  const {
+    control,
+    handleSubmit,
+    formState: { errors },
+    setValue,
+  } = useForm<OrderDeliveryAddress>({
+    resolver: yupResolver(deliveryAddressSchema),
+    defaultValues: {
+      local: DEFAULT_CITY,
+      street: "",
+      number: "",
+      reference: "",
+    },
+  });
+
+  const defaultAddress = addresses.find(
+    (address) => address.isDefault === true,
+  );
 
   const orderSummary = useMemo(() => {
     const itemsWithSubtotal = params.orderPayload.items.map((item) => ({
@@ -39,7 +70,7 @@ export const useOrderAddress = () => {
       params.orderPayload.items.reduce((sum, item) => sum + item.quantity, 0) +
       (params.orderPayload.addons?.reduce(
         (sum, addon) => sum + addon.quantity,
-        0
+        0,
       ) || 0);
 
     return {
@@ -49,17 +80,29 @@ export const useOrderAddress = () => {
     };
   }, [params.orderPayload]);
 
-  async function handleCreateOrder() {
+  async function submitOrder(deliveryAddress?: OrderDeliveryAddress) {
     setIsLoading(true);
     try {
-      await postOrder(params.orderPayload);
+      let orderRequestBody: OrderPayload = {
+        items: params.orderPayload.items,
+        addons: params.orderPayload.addons,
+      };
+
+      if (isAdmin && deliveryAddress) {
+        orderRequestBody = {
+          ...orderRequestBody,
+          customAddress: deliveryAddress,
+        };
+      }
+
+      await postOrder(orderRequestBody);
 
       Toast.show({
         type: "success",
         text1: "Pedido realizado com sucesso!",
       });
 
-      navigate("userHome");
+      navigate(homeRouteName);
     } catch (error) {
       if (isAxiosError(error)) {
         Toast.show({
@@ -70,6 +113,14 @@ export const useOrderAddress = () => {
     } finally {
       setIsLoading(false);
     }
+  }
+
+  async function handleCreateOrder() {
+    await submitOrder();
+  }
+
+  async function handleCreateAdminOrder(deliveryAddress: OrderDeliveryAddress) {
+    await submitOrder(deliveryAddress);
   }
 
   const handChangeAddress = () => {
@@ -83,7 +134,17 @@ export const useOrderAddress = () => {
     params,
     address: defaultAddress,
     isLoading,
+    isAdmin,
     handleCreateOrder,
+    handleCreateAdminOrder,
+    handleSubmit,
+    control,
+    errors,
+    setValue,
+    mainLocal,
+    setMainLocal,
+    selectedEngenho,
+    setSelectedEngenho,
     navigate,
     orderSummary,
     handChangeAddress,

--- a/src/screens/user/orders-list/index.tsx
+++ b/src/screens/user/orders-list/index.tsx
@@ -6,6 +6,7 @@ import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import DateTimePicker from "@react-native-community/datetimepicker";
 import dayjs from "dayjs";
+import { useState } from "react";
 import { Dropdown } from "react-native-element-dropdown";
 import { getOrdersFilterAppearance } from "src/helpers/orders-filter-appearance";
 import {
@@ -15,15 +16,19 @@ import {
 } from "src/helpers/order-status";
 import theme from "src/styles/theme";
 import { OrderStatusProps } from "src/types/orders";
+import { ProductName } from "src/types/stock";
 import * as S from "./styles";
 import { useOrdersList } from "./use-orders-list";
 
-type OrderDetailNavigationProp = NativeStackNavigationProp<{
+type OrdersListNavigationProp = NativeStackNavigationProp<{
   orderDetail: { orderId: number };
+  userCreateOrder: { type: ProductName };
 }>;
 
 export const OrdersListScreen = () => {
-  const navigation = useNavigation<OrderDetailNavigationProp>();
+  const navigation = useNavigation<OrdersListNavigationProp>();
+  const [isCreateOrderMenuVisible, setIsCreateOrderMenuVisible] =
+    useState(false);
   const {
     openDatePicker,
     handleDateChange,
@@ -48,6 +53,24 @@ export const OrdersListScreen = () => {
     date,
     hasActiveFilters: haveFilters,
   });
+
+  function closeCreateOrderMenu() {
+    setIsCreateOrderMenuVisible(false);
+  }
+
+  function toggleCreateOrderMenu() {
+    setIsCreateOrderMenuVisible((isVisible) => !isVisible);
+  }
+
+  function handleCreateOrder(productType: ProductName) {
+    closeCreateOrderMenu();
+    navigation.navigate("userCreateOrder", { type: productType });
+  }
+
+  let createOrderFabIconName: "plus" | "x" = "plus";
+  if (isCreateOrderMenuVisible) {
+    createOrderFabIconName = "x";
+  }
 
   return (
     <LinearGradientBackground>
@@ -207,6 +230,34 @@ export const OrdersListScreen = () => {
           onEndList={onEndList}
         />
       </S.Container>
+      {isAdminView && isCreateOrderMenuVisible && (
+        <>
+          <S.CreateOrderBackdrop onPress={closeCreateOrderMenu} />
+          <S.CreateOrderActions>
+            <S.CreateOrderActionRow onPress={() => handleCreateOrder("GAS")}>
+              <S.CreateOrderActionLabel>Pedir Gás</S.CreateOrderActionLabel>
+              <S.CreateOrderActionButton>
+                <Feather name="zap" size={18} color={theme.colors.ORANGE_200} />
+              </S.CreateOrderActionButton>
+            </S.CreateOrderActionRow>
+            <S.CreateOrderActionRow onPress={() => handleCreateOrder("WATER")}>
+              <S.CreateOrderActionLabel>Pedir Água</S.CreateOrderActionLabel>
+              <S.CreateOrderActionButton>
+                <Feather name="droplet" size={18} color={theme.colors.BLUE} />
+              </S.CreateOrderActionButton>
+            </S.CreateOrderActionRow>
+          </S.CreateOrderActions>
+        </>
+      )}
+      {isAdminView && (
+        <S.CreateOrderFab onPress={toggleCreateOrderMenu}>
+          <Feather
+            name={createOrderFabIconName}
+            size={24}
+            color={theme.colors.WHITE}
+          />
+        </S.CreateOrderFab>
+      )}
     </LinearGradientBackground>
   );
 };

--- a/src/screens/user/orders-list/index.tsx
+++ b/src/screens/user/orders-list/index.tsx
@@ -6,7 +6,6 @@ import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import DateTimePicker from "@react-native-community/datetimepicker";
 import dayjs from "dayjs";
-import { useState } from "react";
 import { Dropdown } from "react-native-element-dropdown";
 import { getOrdersFilterAppearance } from "src/helpers/orders-filter-appearance";
 import {
@@ -16,19 +15,16 @@ import {
 } from "src/helpers/order-status";
 import theme from "src/styles/theme";
 import { OrderStatusProps } from "src/types/orders";
-import { ProductName } from "src/types/stock";
 import * as S from "./styles";
 import { useOrdersList } from "./use-orders-list";
 
 type OrdersListNavigationProp = NativeStackNavigationProp<{
   orderDetail: { orderId: number };
-  userCreateOrder: { type: ProductName };
+  userCreateOrder: { type?: string };
 }>;
 
 export const OrdersListScreen = () => {
   const navigation = useNavigation<OrdersListNavigationProp>();
-  const [isCreateOrderMenuVisible, setIsCreateOrderMenuVisible] =
-    useState(false);
   const {
     openDatePicker,
     handleDateChange,
@@ -54,22 +50,8 @@ export const OrdersListScreen = () => {
     hasActiveFilters: haveFilters,
   });
 
-  function closeCreateOrderMenu() {
-    setIsCreateOrderMenuVisible(false);
-  }
-
-  function toggleCreateOrderMenu() {
-    setIsCreateOrderMenuVisible((isVisible) => !isVisible);
-  }
-
-  function handleCreateOrder(productType: ProductName) {
-    closeCreateOrderMenu();
-    navigation.navigate("userCreateOrder", { type: productType });
-  }
-
-  let createOrderFabIconName: "plus" | "x" = "plus";
-  if (isCreateOrderMenuVisible) {
-    createOrderFabIconName = "x";
+  function handleCreateOrder() {
+    navigation.navigate("userCreateOrder", {});
   }
 
   return (
@@ -230,32 +212,9 @@ export const OrdersListScreen = () => {
           onEndList={onEndList}
         />
       </S.Container>
-      {isAdminView && isCreateOrderMenuVisible && (
-        <>
-          <S.CreateOrderBackdrop onPress={closeCreateOrderMenu} />
-          <S.CreateOrderActions>
-            <S.CreateOrderActionRow onPress={() => handleCreateOrder("GAS")}>
-              <S.CreateOrderActionLabel>Pedir Gás</S.CreateOrderActionLabel>
-              <S.CreateOrderActionButton>
-                <Feather name="zap" size={18} color={theme.colors.ORANGE_200} />
-              </S.CreateOrderActionButton>
-            </S.CreateOrderActionRow>
-            <S.CreateOrderActionRow onPress={() => handleCreateOrder("WATER")}>
-              <S.CreateOrderActionLabel>Pedir Água</S.CreateOrderActionLabel>
-              <S.CreateOrderActionButton>
-                <Feather name="droplet" size={18} color={theme.colors.BLUE} />
-              </S.CreateOrderActionButton>
-            </S.CreateOrderActionRow>
-          </S.CreateOrderActions>
-        </>
-      )}
       {isAdminView && (
-        <S.CreateOrderFab onPress={toggleCreateOrderMenu}>
-          <Feather
-            name={createOrderFabIconName}
-            size={24}
-            color={theme.colors.WHITE}
-          />
+        <S.CreateOrderFab onPress={handleCreateOrder}>
+          <Feather name="plus" size={24} color={theme.colors.WHITE} />
         </S.CreateOrderFab>
       )}
     </LinearGradientBackground>

--- a/src/screens/user/orders-list/styles.ts
+++ b/src/screens/user/orders-list/styles.ts
@@ -235,14 +235,6 @@ export const dropdownMenuItemContainerStyle = {
   paddingHorizontal: 0,
 };
 
-export const CreateOrderBackdrop = styled.Pressable`
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-`;
-
 export const CreateOrderFab = styled.TouchableOpacity`
   position: absolute;
   right: ${theme.size.m5};
@@ -258,43 +250,4 @@ export const CreateOrderFab = styled.TouchableOpacity`
   shadow-opacity: 0.25;
   shadow-radius: 8px;
   shadow-offset: 0px 4px;
-`;
-
-export const CreateOrderActions = styled.View`
-  position: absolute;
-  right: ${theme.size.m5};
-  bottom: 88px;
-  align-items: flex-end;
-  gap: ${theme.size.m3};
-`;
-
-export const CreateOrderActionRow = styled.TouchableOpacity`
-  flex-direction: row;
-  align-items: center;
-  gap: ${theme.size.m3};
-`;
-
-export const CreateOrderActionLabel = styled.Text`
-  color: ${theme.colors.GRAY_700};
-  background-color: ${theme.colors.WHITE};
-  font-size: ${theme.font.size.m3};
-  font-weight: ${theme.font.weight.bold};
-  padding: ${theme.size.m2} ${theme.size.m3};
-  border-radius: ${theme.size.m3};
-  elevation: 4;
-  overflow: hidden;
-`;
-
-export const CreateOrderActionButton = styled.View`
-  width: 44px;
-  height: 44px;
-  border-radius: 22px;
-  background-color: ${theme.colors.WHITE};
-  align-items: center;
-  justify-content: center;
-  elevation: 4;
-  shadow-color: ${theme.colors.GRAY_700};
-  shadow-opacity: 0.18;
-  shadow-radius: 6px;
-  shadow-offset: 0px 2px;
 `;

--- a/src/screens/user/orders-list/styles.ts
+++ b/src/screens/user/orders-list/styles.ts
@@ -234,3 +234,67 @@ export const dropdownMenuContainerStyle = {
 export const dropdownMenuItemContainerStyle = {
   paddingHorizontal: 0,
 };
+
+export const CreateOrderBackdrop = styled.Pressable`
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+`;
+
+export const CreateOrderFab = styled.TouchableOpacity`
+  position: absolute;
+  right: ${theme.size.m5};
+  bottom: ${theme.size.m6};
+  width: 56px;
+  height: 56px;
+  border-radius: 28px;
+  background-color: ${theme.colors.ORANGE_200};
+  align-items: center;
+  justify-content: center;
+  elevation: 6;
+  shadow-color: ${theme.colors.GRAY_700};
+  shadow-opacity: 0.25;
+  shadow-radius: 8px;
+  shadow-offset: 0px 4px;
+`;
+
+export const CreateOrderActions = styled.View`
+  position: absolute;
+  right: ${theme.size.m5};
+  bottom: 88px;
+  align-items: flex-end;
+  gap: ${theme.size.m3};
+`;
+
+export const CreateOrderActionRow = styled.TouchableOpacity`
+  flex-direction: row;
+  align-items: center;
+  gap: ${theme.size.m3};
+`;
+
+export const CreateOrderActionLabel = styled.Text`
+  color: ${theme.colors.GRAY_700};
+  background-color: ${theme.colors.WHITE};
+  font-size: ${theme.font.size.m3};
+  font-weight: ${theme.font.weight.bold};
+  padding: ${theme.size.m2} ${theme.size.m3};
+  border-radius: ${theme.size.m3};
+  elevation: 4;
+  overflow: hidden;
+`;
+
+export const CreateOrderActionButton = styled.View`
+  width: 44px;
+  height: 44px;
+  border-radius: 22px;
+  background-color: ${theme.colors.WHITE};
+  align-items: center;
+  justify-content: center;
+  elevation: 4;
+  shadow-color: ${theme.colors.GRAY_700};
+  shadow-opacity: 0.18;
+  shadow-radius: 6px;
+  shadow-offset: 0px 2px;
+`;

--- a/src/services/order/types.ts
+++ b/src/services/order/types.ts
@@ -1,3 +1,10 @@
+export type OrderDeliveryAddress = {
+  street?: string;
+  number?: string;
+  reference: string;
+  local: string;
+};
+
 export type OrderPayload = {
   items: Array<{
     id: number;
@@ -9,6 +16,7 @@ export type OrderPayload = {
     type: string;
     quantity: number;
   }>;
+  customAddress?: OrderDeliveryAddress;
 };
 
 export type StockData = {


### PR DESCRIPTION
## Summary

- Restaura criação de pedidos pelo admin a partir da lista de pedidos, via floating action button, mantendo o pedido vinculado ao usuário admin
- Aprimora layout da tela de criação de pedido para os tipos refil, vasilhame e misto
- Adiciona validação de endereço no fluxo admin e corrige copy do vasilhame

## Arquivos alterados

- `src/screens/user/create-order/` — layout e lógica de criação de pedido
- `src/screens/user/order-address/` — tela de endereço com suporte ao fluxo admin
- `src/screens/user/orders-list/` — botão de ação flutuante para admin
- `src/helpers/order-item-labels.ts` — labels dos itens de pedido
- `src/helpers/authenticated-home-route.ts` — rota inicial autenticada
- `src/routes/` — ajustes de navegação admin e usuário
- `src/services/order/types.ts` — novos tipos de pedido

## Test plan

- [ ] Admin consegue criar pedido de gás a partir da lista de pedidos
- [ ] Admin consegue criar pedido de água a partir da lista de pedidos
- [ ] Endereço de entrega é validado antes de prosseguir
- [ ] Layout de criação de pedido está correto para tipos: refil, vasilhame e misto
- [ ] Copy do vasilhame está correto
- [ ] Fluxo de usuário comum não foi afetado